### PR TITLE
Address docs build warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -379,6 +379,8 @@ for _, f in snp_func:
             f.__doc__,
             flags=re.M,
         )
+        # Remove cross-references to section NEP35
+        f.__doc__ = re.sub(":ref:`NEP 35 <NEP35>`", "NEP 35", f.__doc__, re.M)
         # Remove cross-reference to numpydoc style references section
         f.__doc__ = re.sub(r" \[(\d+)\]_", "", f.__doc__, flags=re.M)
         # Remove entire numpydoc references section

--- a/scico/numpy/__init__.py
+++ b/scico/numpy/__init__.py
@@ -5,7 +5,7 @@
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""Construct wrapped versions of :mod:`jax.numpy` functions.
+"""Wrapped versions of :mod:`jax.numpy` functions.
 
 This modules consists of functions from :mod:`jax.numpy`. Some of these functions are wrapped to support compatibility with :class:`scico.blockarray.BlockArray` and are documented here. The remaining functions are imported directly from :mod:`jax.numpy`. While they can be imported from the :mod:`scico.numpy` namespace, they are not documented here; please consult the documentation for the source module :mod:`jax.numpy`.
 

--- a/scico/scipy/__init__.py
+++ b/scico/scipy/__init__.py
@@ -1,1 +1,13 @@
+# e -*- coding: utf-8 -*-
+# Copyright (C) 2021 by SCICO Developers
+# All rights reserved. BSD 3-clause License.
+# This file is part of the SCICO package. Details of the copyright and
+# user license can be found in the 'LICENSE' file distributed with the
+# package.
+
+"""Wrapped versions of :mod:`jax.scipy` functions.
+
+This modules currently serves simply as a namespace for :mod:`scico.scipy.special`.
+"""
+
 from . import special

--- a/scico/scipy/special.py
+++ b/scico/scipy/special.py
@@ -5,7 +5,7 @@
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""Construct wrapped versions of :mod:`jax.scipy.special` functions.
+"""Wrapped versions of :mod:`jax.scipy.special` functions.
 
 This modules consists of functions from :mod:`jax.scipy.special`. Some of these functions are wrapped to support compatibility with :class:`scico.blockarray.BlockArray` and are documented here. The remaining functions are imported directly from :mod:`jax.numpy`. While they can be imported from the :mod:`scico.numpy` namespace, they are not documented here; please consult the documentation for the source module :mod:`jax.scipy.special`.
 """


### PR DESCRIPTION
Address docs build warnings due to `NEP35` cross reference in docstrings of some functions imported from `numpy`.