### PR TITLE
Fixed SSLCertificate Error in Get_URL

### DIFF
--- a/scico/test/test_util.py
+++ b/scico/test/test_util.py
@@ -48,7 +48,7 @@ def test_url_get():
     url = "about:blank"
     np.testing.assert_raises(urlerror.URLError, url_get, url)
 
-    url = "https://webpages.tuni.fi/foi/GCF-BM3D/BM3D_TIP_2007.pdf"
+    url = "https://github.com/lanl/scico/blob/main/README.rst"
     np.testing.assert_raises(ValueError, url_get, url, -1)
 
 


### PR DESCRIPTION
The URL was failing to retrieve the document due to certificate errors. Changed link to a smaller-sized link hosted on GitHub for easier access.