### PR TITLE
Check todo in docs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,10 +1,17 @@
-************
-Installation
-************
-
-
 Installing SCICO
 ================
+
+SCICO requires Python version 3.8 or later. It has been tested on Linux and macOS, but is not currently supported on Windows due to the limited support for ``jaxlib`` on Windows. However, Windows users can use SCICO via the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/about>`_. Guides exist for using WSL with `CPU only <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and with
+`GPU support <https://docs.microsoft.com/en-us/windows/win32/direct3d12/gpu-cuda-in-wsl>`_.
+
+
+From PyPI
+---------
+
+.. warning::
+   Installation from PyPI is not currently recommended since the current
+   package available from PyPI is a pre-release testing version. The
+   instructions directly below are intended for post-release documentation.
 
 The simplest way to install the most recent release of SCICO from
 `PyPI <https://pypi.python.org/pypi/scico/>`_ is
@@ -14,20 +21,31 @@ The simplest way to install the most recent release of SCICO from
       pip install scico
 
 
+From GitHub
+-----------
 
-Installing Dependencies
------------------------
+SCICO can be downloaded from the `GitHub repo <https://github.com/lanl/scico>`_. Note that, since the SCICO repo has a submodule, it should be cloned via the command
 
-For detailed instructions on how to install a CPU-only version see `Installing a Development Version`_.
+::
+
+   git clone --recurse-submodules git@github.com:lanl/scico.git
+
+Install using the commands
+
+::
+
+   cd scico
+   pip install -r requirements.txt
+   pip install -e .
 
 
 
-GPU Enabled
-###########
+GPU Support
+-----------
 
-By default, ``pip install -r requirements.txt`` will install a CPU-only version of SCICO. To install a version with GPU support:
+The instructions above install a CPU-only version of SCICO. To install a version with GPU support:
 
-1. Follow the CPU Only instructions, above
+1. Follow the CPU only instructions, above
 
 2. Identify which version of jaxlib was installed
 
@@ -45,8 +63,8 @@ By default, ``pip install -r requirements.txt`` will install a CPU-only version 
 
 
 
-Additional Dependencies for Tomography
-######################################
+Additional Dependencies
+-----------------------
 
 We use the `ASTRA Toolbox <https://www.astra-toolbox.com/>`_ for tomographic projectors. We currently require the development version of ASTRA, as suggested by the package maintainers.
 
@@ -58,17 +76,9 @@ The development version of ASTRA can be installed using conda:
 
 Alternatively, it can be `built from source <https://www.astra-toolbox.com/docs/install.html#for-python>`_.
 
-We also support the `Super-Voxel Model-Based Iterative Reconstruction <https://svmbir.readthedocs.io/en/latest/>`_ package as an alternative tomographic projector. Since this package can be installed via pip, it is
-included in the list of package dependencies (`requirements.txt`), and need
+We also support the `Super-Voxel Model-Based Iterative Reconstruction <https://svmbir.readthedocs.io/en/latest/>`_ package as an alternative tomographic projector. Since this package can be installed via ``pip``, it is
+included in the list of package dependencies (``requirements.txt``), and need
 not be separately installed.
-
-
-
-SCICO on Windows
-----------------
-
-We do not support using SCICO on Windows. Our advice for users on Windows is to use Linux inside a virtual machine. Microsoft's `WSL <https://docs.microsoft.com/en-us/windows/wsl/about>`_ is one such solution. Guides exist for using WSL with the `CPU only <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and with `GPU support <https://docs.microsoft.com/en-us/windows/win32/direct3d12/gpu-cuda-in-wsl>`_.
-
 
 
 For Developers
@@ -83,7 +93,6 @@ In the cloned repository root directory, set up the pre-commit hook:
 ::
 
    pre-commit install
-
 
 
 Building Documentation

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -15,58 +15,11 @@ Installing SCICO
        pip install scico
 
 
-Once it has been released, installation of SCICO via ``pip`` and ``conda`` will be supported. At the moment, SCICO should be downloaded from the `GitHub repo <https://github.com/lanl/scico>`_. Note that, since the SCICO repo has a submodule, it should be cloned via the command
-
-::
-
-   git clone --recurse-submodules git@github.com:lanl/scico.git
-
-Once the dependencies have been installed, as described below, install SCICO itself in editable form
-
-::
-
-   cd scico
-   pip install -e .
-
 
 Installing Dependencies
-=======================
+-----------------------
 
-Note that SCICO requires Python version 3.8 or later.
-
-
-Automatic Installation
-----------------------
-
-The recommended way to install SCICO and its dependencies is via `conda <https://docs.conda.io/en/latest/>`_ using the scripts in ``misc/conda``:
-
-  - ``install_conda.sh``: install ``miniconda``
-    (needed if conda is not already installed on your system).
-  - ``conda_env.sh``: install a ``conda`` environment
-    with all SCICO dependencies. For GPU installation, see ``conda_env.sh -h``.
-
-
-Manual Installation
--------------------
-
-SCICO and its dependencies may also be installed manually.  Installation depends on whether SCICO is intended to run on CPUs only, or whether GPU support is also required.
-
-CPU Only
-########
-
-1. Clone the repository
-
-2. Navigate to the repository root directory
-
-   ::
-
-      cd scico
-
-3. Install dependencies
-
-   ::
-
-      pip install -r requirements.txt
+For detailed instructions on how to install a CPU-only version see `Installing a Development Version`_.
 
 
 
@@ -118,8 +71,9 @@ SCICO on Windows
 We do not support using SCICO on Windows. Our advice for users on Windows is to use Linux inside a virtual machine. Microsoft's `WSL <https://docs.microsoft.com/en-us/windows/wsl/about>`_ is one such solution. Guides exist for using WSL with the `CPU only <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and with `GPU support <https://docs.microsoft.com/en-us/windows/win32/direct3d12/gpu-cuda-in-wsl>`_.
 
 
+
 For Developers
-==============
+--------------
 
 The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_
 and `isort <https://pypi.org/project/isort/>`_ code formatting utilities.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,13 +6,12 @@ Installation
 Installing SCICO
 ================
 
-..
-   The simplest way to install the most recent release of SCICO from
-   `PyPI <https://pypi.python.org/pypi/scico/>`_ is
+The simplest way to install the most recent release of SCICO from
+`PyPI <https://pypi.python.org/pypi/scico/>`_ is
 
    ::
 
-       pip install scico
+      pip install scico
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ SCICO is a Python package for solving the inverse problems that arise in scienti
 Installation
 ============
 
-See the ``INSTALL.rst`` file or the `online documentation <https://scico.rtfd.io/en/latest/install.html>`_ for installation instructions.
+See the `online documentation <https://scico.rtfd.io/en/latest/install.html>`_ for installation instructions.
 
 
 Usage Examples

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -33,8 +33,7 @@ Contributions to SCICO are welcome. Before starting work, please contact the mai
 Installing a Development Version
 --------------------------------
 
-1. Fork both the scico and scico-data repositories, creating copies of these
-respositories in your own git account.
+1. Fork both the scico and scico-data repositories, creating copies of these repositories in your own git account.
 
 2. Make sure that you have python >= 3.8 installed in order to create a conda virtual environment.
 
@@ -56,7 +55,7 @@ respositories in your own git account.
 
    ::
 
-      conda activate scico 
+      conda activate scico
 
 
 6. Navigate to the root of the cloned repository:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -35,7 +35,7 @@ Installing a Development Version
 --------------------------------
 
 
-1. Fork both the SCICO repository and the SCICO Data submodule by clicking the Fork button on the [repository page](https://github.com/lanl/scico). This will create a copy of both SCICO and SCICO Data repositories in your Git account.
+1. Fork both the SCICO repository and the SCICO Data submodule by clicking the Fork button on the `repository page <https://github.com/lanl/scico>`_. This will create a copy of both SCICO and SCICO Data repositories in your Git account.
 
 
 2. Make sure that you have Python >= 3.8 installed in order to create a conda virtual environment.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -41,14 +41,14 @@ Installing a Development Version
 2. Make sure that you have Python >= 3.8 installed in order to create a conda virtual environment.
 
 
-3. To create a conda virtual environment, clone your fork from source. To do a clone on SCICO that includes the SCICO Data submodule you need to do:
+3. To create a conda virtual environment, clone your fork from source. To do a clone on SCICO that includes the SCICO Data submodule:
 
 ::
 
    git clone --recurse-submodules git@github.com:<username>/scico.git
 
 
-4. Add the SCICO repo as an upstream remote to sync your changes.
+4. Add the SCICO repo as an upstream remote to sync your changes:
 
 ::
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,21 +82,14 @@ Installing a Development Version
       pip install -e .  # Installs SCICO from the current directory in editable mode
 
 
-9. Once dependencies have been installed, install SCICO in editable form:
-
-   ::
-
-      pip install -e .
-
-
-10. Set up ``black`` and ``isort`` pre-commit hooks:
+9. Set up ``black`` and ``isort`` pre-commit hooks:
 
    ::
 
       pre-commit install  # Sets up git pre-commit hooks
 
 
-11. For testing see `Tests`_.
+10. For testing see `Tests`_.
 
 
 Contributing Code

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,7 +82,10 @@ Installing a Development Version
       pip install -e .  # Installs SCICO from the current directory in editable mode
 
 
-9. Set up ``black`` and ``isort`` pre-commit hooks:
+9. The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_
+   and `isort <https://pypi.org/project/isort/>`_ code formatting utilities.
+   You should set up a `pre-commit hook <https://pre-commit.com>`_ to ensure
+   any modified code passes format check before it is committed to the development repo:
 
    ::
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -35,58 +35,62 @@ Installing a Development Version
 --------------------------------
 
 
-.. todo::
-
-   At time of public release, this should be updated to a forking tutorial (see
-   `the jax example <https://jax.readthedocs.io/en/latest/contributing.html#contributing-code-using-pull-requests>`_)
+1. Fork both the SCICO repository and the SCICO Data submodule by clicking the Fork button on the [repository page](https://github.com/lanl/scico). This will create a copy of both SCICO and SCICO Data repositories in your Git account.
 
 
-1. Create a conda environment using Python >= 3.8:
-
-::
-
-   conda create -n scico python=3.8
+2. Make sure that you have Python >= 3.8 installed in order to create a conda virtual environment.
 
 
-2. Activate the conda virtual environment:
+3. To create a conda virtual environment, clone your fork from source. To do a clone on SCICO that includes the SCICO Data submodule you need to do:
 
 ::
 
-   conda activate scico
+   git clone --recurse-submodules git@github.com:<username>/scico.git
 
-3. Clone the SCICO repository:
+
+4. Add the SCICO repo as an upstream remote to sync your changes.
 
 ::
 
-   git clone https://github.com/lanl/scico.git --recurse-submodules
+   git remote add upstream https://www.github.com/lanl/scico
 
 
-4. Navigate to the cloned repository:
+5. After adding the upstream, the recommended way to install SCICO and its dependencies is via `conda <https://docs.conda.io/en/latest/>`_ using the scripts in ``misc/conda``:
+
+  - ``install_conda.sh``: install ``miniconda``
+    (needed if conda is not already installed on your system).
+  - ``conda_env.sh``: install a ``conda`` environment
+    with all SCICO dependencies. For GPU installation, see ``conda_env.sh -h``.
+
+
+5. Activate the created conda virtual environment:
+
+::
+
+   conda activate py38
+
+
+6. Navigate to the root of the cloned repository:
 
 ::
 
     cd scico
 
-5. Install dependencies:
+7. Once dependencies have been installed, install SCICO in editable form:
 
 ::
 
-  pip install -r requirements.txt  # Installs basic requirements
-  pip install -r docs/docs_requirements.txt # Installs documentation requirements
-  pip install -r examples/examples_requirements.txt # Installs example requirements
-  pip install -e .  # Installs SCICO from the current directory in editable mode.
+  pip install -e .
 
-6. Set up ``black`` and ``isort`` pre-commit hooks:
+
+8. Set up ``black`` and ``isort`` pre-commit hooks:
 
 ::
 
   pre-commit install  # Sets up git pre-commit hooks
 
-7. If desired, tests can be run on the installed version:
 
-::
-
-   pytest --pyargs scico
+9. For testing see `Tests`_.
 
 
 Contributing Code
@@ -99,7 +103,9 @@ Contributing Code
 
 A feature development workflow might look like this:
 
+
 1. Follow the instructions in `Installing a Development Version`_.
+
 
 2. Sync with the upstream repository:
 
@@ -107,13 +113,16 @@ A feature development workflow might look like this:
 
    git pull --rebase origin main --recurse-submodules
 
+
 3. Create a branch to develop from:
 
 ::
 
    git checkout -b name-of-change
 
+
 4. Make your desired changes.
+
 
 5. Run the test suite:
 
@@ -126,6 +135,7 @@ You can limit the test suite to a specific file:
 ::
 
    pytest scico/test/test_blockarray.py
+
 
 6. When you are finished making changes, create a new commit:
 
@@ -141,7 +151,8 @@ NOTE:  If you have added or modified an example script, see `Adding Usage Exampl
 
 ::
 
-   git pull --rebase origin main --recurse-submodules
+   git fetch upstream
+   git rebase upstream/main
 
 
 8. Push your development upstream:
@@ -150,7 +161,9 @@ NOTE:  If you have added or modified an example script, see `Adding Usage Exampl
 
    git push --set-upstream origin name-of-change
 
+
 9.  Create a new pull request to the ``main`` branch; see `the GitHub instructions <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_.
+
 
 10. Delete the branch after it has been merged.
 
@@ -180,15 +193,19 @@ particular:
   Script description.
   """
 
+
 2. The final line of the script is an ``input`` statement intended to avoid the script terminating immediately, thereby closing all figures:
 
 ::
 
   input("\nWaiting for input to close figures and exit")
 
+
 3. Citations are included using the standard `Sphinx <https://www.sphinx-doc.org/en/master/>`__ ``:cite:`cite-key``` syntax, where ``cite-key`` is the key of an entry in ``docs/source/references.bib``.
 
+
 4. Cross-references to other components of the documentation are included using the syntax described in the `nbsphinx documentation <https://nbsphinx.readthedocs.io/en/0.3.5/markdown-cells.html#Links-to-*.rst-Files-(and-Other-Sphinx-Source-Files)>`__.
+
 
 5. External links are included using Markdown syntax ``[link text](url)``.
 
@@ -212,13 +229,16 @@ and ``scico-data`` repositories must be updated and kept in sync.
 
 1. Add the ``new_example.py`` script to the ``scico/examples/scripts`` directory.
 
+
 2. Add the basename of the script (i.e., without the pathname; in this case,
 ``new_example.py``) to the appropriate section of
 ``examples/scripts/index.rst``.
 
+
 3. Convert your new example to a Jupyter notebook by changing directory to the ``scico/examples`` directory and following the instructions in ``scico/examples/README.rst``.
 
-4.  Change directory to the ``data`` directory and add/commit the new Jupyter Notebook:
+
+4. Change directory to the ``data`` directory and add/commit the new Jupyter Notebook:
 
 ::
 
@@ -226,7 +246,8 @@ and ``scico-data`` repositories must be updated and kept in sync.
    git add notebooks/new_example.ipynb
    git commit -m "Add new usage example"
 
-5.  Return to the main SCICO repository, ensure the ``main`` branch is checked out, add/commit the new script and updated submodule:
+
+5. Return to the main SCICO repository, ensure the ``main`` branch is checked out, add/commit the new script and updated submodule:
 
 ::
 
@@ -234,6 +255,7 @@ and ``scico-data`` repositories must be updated and kept in sync.
    git add data
    git add examples/scripts/new_filename.py
    git commit -m "Add usage example and update data module"
+
 
 6.  Push both repositories:
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -35,11 +35,10 @@ Installing a Development Version
 --------------------------------
 
 
-1. Fork both the SCICO repository and the SCICO Data submodule by clicking the Fork button on the `repository page <https://github.com/lanl/scico>`_. This will create a copy of both SCICO and SCICO Data repositories in your Git account.
-
+1. Fork both the scico and scico-data repositories, creating copies of these
+respositories in your own git account.
 
 2. Make sure that you have Python >= 3.8 installed in order to create a conda virtual environment.
-
 
 3. To create a conda virtual environment, clone your fork from source. To do a clone on SCICO that includes the SCICO Data submodule:
 
@@ -47,13 +46,11 @@ Installing a Development Version
 
    git clone --recurse-submodules git@github.com:<username>/scico.git
 
-
 4. Add the SCICO repo as an upstream remote to sync your changes:
 
 ::
 
    git remote add upstream https://www.github.com/lanl/scico
-
 
 5. After adding the upstream, the recommended way to install SCICO and its dependencies is via `conda <https://docs.conda.io/en/latest/>`_ using the scripts in ``misc/conda``:
 
@@ -63,34 +60,34 @@ Installing a Development Version
     with all SCICO dependencies. For GPU installation, see ``conda_env.sh -h``.
 
 
-5. Activate the created conda virtual environment:
+6. Activate the created conda virtual environment:
 
 ::
 
    conda activate py38
 
 
-6. Navigate to the root of the cloned repository:
+7. Navigate to the root of the cloned repository:
 
 ::
 
     cd scico
 
-7. Once dependencies have been installed, install SCICO in editable form:
+8. Once dependencies have been installed, install SCICO in editable form:
 
 ::
 
   pip install -e .
 
 
-8. Set up ``black`` and ``isort`` pre-commit hooks:
+9. Set up ``black`` and ``isort`` pre-commit hooks:
 
 ::
 
   pre-commit install  # Sets up git pre-commit hooks
 
 
-9. For testing see `Tests`_.
+10. For testing see `Tests`_.
 
 
 Contributing Code

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -33,7 +33,7 @@ Contributions to SCICO are welcome. Before starting work, please contact the mai
 Installing a Development Version
 --------------------------------
 
-1. Fork both the scico and scico-data repositories, creating copies of these repositories in your own git account.
+1. Fork both the ``scico`` and ``scico-data`` repositories, creating copies of these repositories in your own git account.
 
 2. Make sure that you have python >= 3.8 installed in order to create a conda virtual environment.
 
@@ -44,7 +44,7 @@ Installing a Development Version
       git clone --recurse-submodules git@github.com:<username>/scico.git
 
 
-4. Create a conda environment using Python >= 3.8:
+4. Create a conda environment using python >= 3.8:
 
    ::
 
@@ -143,7 +143,7 @@ A feature development workflow might look like this:
       git add file1.py git add file2.py
       git commit -m "A good commit message"
 
-   NOTE:  If you have added or modified an example script, see `Adding Usage Examples`_
+   NOTE:  If you have added or modified an example script, see `Usage Examples`_
 
 7. Sync with the upstream repository:
 
@@ -166,8 +166,83 @@ A feature development workflow might look like this:
 10. Delete the branch after it has been merged.
 
 
-Adding Usage Examples
----------------------
+Tests
+-----
+
+All functions and classes should have corresponding ``pytest`` unit tests.
+
+
+Running Tests
+^^^^^^^^^^^^^
+
+
+To be able to run the tests, install ``pytest`` and, optionally,
+``pytest-runner``:
+
+::
+
+    conda install pytest pytest-runner
+
+The tests can be run by
+
+::
+
+    pytest
+
+or (if ``pytest-runner`` is installed)
+
+::
+
+    python setup.py test
+
+from the SCICO repository root directory. Tests can be run in an installed
+version of SCICO by
+
+::
+
+   pytest --pyargs scico
+
+
+Test Coverage
+^^^^^^^^^^^^^
+
+Test coverage is a measure of the fraction of the package code that is exercised by the tests. While this should not be the primary criterion in designing tests, it is a useful tool for finding obvious areas of omission.
+
+To be able to check test coverage, install ``coverage``:
+
+::
+
+    conda install coverage
+
+A coverage report can be obtained by
+
+::
+
+    coverage run
+    coverage report
+
+
+
+Type Checking
+-------------
+
+In the future, we will require all code to pass ``mypy`` type checking. This is not currently enforced.
+
+Install ``mypy``:
+
+::
+
+   conda install mypy
+
+To run the type checker on the ``scico`` module:
+
+::
+
+   mypy -p scico
+
+
+Usage Examples
+--------------
 
 New usage examples should adhere to the same general structure as the
 existing examples to ensure that the mechanism for automatically
@@ -262,8 +337,8 @@ and ``scico-data`` repositories must be updated and kept in sync.
       git submodule foreach --recursive 'git push' && git push
 
 
-Adding New Data
----------------
+Data
+----
 
 The following steps show how to add new data, ``new_data.npz``, to the packaged data. We assume the SCICO repository has been cloned to ``scico/``.
 
@@ -298,79 +373,12 @@ scico-data repositories must be updated and kept in sync.
       git submodule foreach --recursive 'git push' && git push
 
 
-Tests
-=====
-
-All functions and classes should have corresponding `pytest` unit tests.
-
-
-Running Tests
--------------
-
-
-To be able to run the tests, install `pytest` and, optionally, `pytest-runner`:
-
-::
-
-    conda install pytest pytest-runner
-
-The tests can be run by
-
-::
-
-    pytest
-
-or
-
-::
-
-    python setup.py test
-
-
-Type Checking
--------------
-
-In the future, we will require all code to pass `mypy` type checking.  This is not currently enforced.
-
-Install ``mypy``:
-
-::
-
-   conda install mypy
-
-To run the type checker on the ``scico`` module:
-
-::
-
-   mypy -p scico
-
-
 
 Building Documentation
-======================
+----------------------
 
 To build a local copy of the docs, from the repo root directory, do
 
 ::
 
   python setup.py build_sphinx
-
-
-
-Test Coverage
--------------
-
-Test coverage is a measure of the fraction of the package code that is exercised by the tests. While this should not be the primary criterion in designing tests, it is a useful tool for finding obvious areas of omission.
-
-To be able to check test coverage, install `coverage`:
-
-::
-
-    conda install coverage
-
-A coverage report can be obtained by
-
-::
-
-    coverage run
-    coverage report

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -28,29 +28,28 @@ Contributing
 Contributions to SCICO are welcome. Before starting work, please contact the maintainers, either via email or the GitHub issue system, to discuss the relevance of your contribution and the most appropriate location within the existing package structure.
 
 
-
 .. _installing_dev:
 
 Installing a Development Version
 --------------------------------
 
-
 1. Fork both the scico and scico-data repositories, creating copies of these
 respositories in your own git account.
 
-2. Make sure that you have Python >= 3.8 installed in order to create a conda virtual environment.
+2. Make sure that you have python >= 3.8 installed in order to create a conda virtual environment.
 
-3. To create a conda virtual environment, clone your fork from source. To do a clone on SCICO that includes the SCICO Data submodule:
+3. To create a conda virtual environment, clone your fork from the source repo.
+To create a clone of scico that includes the scico-data submodule:
 
-::
+   ::
 
-   git clone --recurse-submodules git@github.com:<username>/scico.git
+      git clone --recurse-submodules git@github.com:<username>/scico.git
 
 4. Add the SCICO repo as an upstream remote to sync your changes:
 
-::
+   ::
 
-   git remote add upstream https://www.github.com/lanl/scico
+      git remote add upstream https://www.github.com/lanl/scico
 
 5. After adding the upstream, the recommended way to install SCICO and its dependencies is via `conda <https://docs.conda.io/en/latest/>`_ using the scripts in ``misc/conda``:
 
@@ -62,29 +61,29 @@ respositories in your own git account.
 
 6. Activate the created conda virtual environment:
 
-::
+   ::
 
-   conda activate py38
+      conda activate py38
 
 
 7. Navigate to the root of the cloned repository:
 
-::
+   ::
 
-    cd scico
+      cd scico
 
 8. Once dependencies have been installed, install SCICO in editable form:
 
-::
+   ::
 
-  pip install -e .
+      pip install -e .
 
 
 9. Set up ``black`` and ``isort`` pre-commit hooks:
 
-::
+   ::
 
-  pre-commit install  # Sets up git pre-commit hooks
+      pre-commit install  # Sets up git pre-commit hooks
 
 
 10. For testing see `Tests`_.
@@ -106,16 +105,16 @@ A feature development workflow might look like this:
 
 2. Sync with the upstream repository:
 
-::
+   ::
 
-   git pull --rebase origin main --recurse-submodules
+      git pull --rebase origin main --recurse-submodules
 
 
 3. Create a branch to develop from:
 
-::
+   ::
 
-   git checkout -b name-of-change
+      git checkout -b name-of-change
 
 
 4. Make your desired changes.
@@ -123,40 +122,39 @@ A feature development workflow might look like this:
 
 5. Run the test suite:
 
-::
+   ::
 
-   pytest
+      pytest
 
-You can limit the test suite to a specific file:
+   You can limit the test suite to a specific file:
 
-::
+   ::
 
-   pytest scico/test/test_blockarray.py
+      pytest scico/test/test_blockarray.py
 
 
 6. When you are finished making changes, create a new commit:
 
-::
+   ::
 
-   git add file1.py git add file2.py
-   git commit -m "A good commit message"
+      git add file1.py git add file2.py
+      git commit -m "A good commit message"
 
-
-NOTE:  If you have added or modified an example script, see `Adding Usage Examples`_
+   NOTE:  If you have added or modified an example script, see `Adding Usage Examples`_
 
 7. Sync with the upstream repository:
 
-::
+   ::
 
-   git fetch upstream
-   git rebase upstream/main
+      git fetch upstream
+      git rebase upstream/main
 
 
 8. Push your development upstream:
 
-::
+   ::
 
-   git push --set-upstream origin name-of-change
+      git push --set-upstream origin name-of-change
 
 
 9.  Create a new pull request to the ``main`` branch; see `the GitHub instructions <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_.
@@ -175,27 +173,27 @@ particular:
 
 1. The initial lines of the script should consist of a comment block, followed by a blank line, followed by a multiline string with an RST heading on the first line, e.g.,
 
-::
+   ::
 
-  #!/usr/bin/env python
-  # -*- coding: utf-8 -*-
-  # This file is part of the SCICO package. Details of the copyright
-  # and user license can be found in the 'LICENSE.txt' file distributed
-  # with the package.
+     #!/usr/bin/env python
+     # -*- coding: utf-8 -*-
+     # This file is part of the SCICO package. Details of the copyright
+     # and user license can be found in the 'LICENSE.txt' file distributed
+     # with the package.
 
-  """
-  Script Title
-  ============
+     """
+     Script Title
+     ============
 
-  Script description.
-  """
+     Script description.
+     """
 
 
 2. The final line of the script is an ``input`` statement intended to avoid the script terminating immediately, thereby closing all figures:
 
-::
+   ::
 
-  input("\nWaiting for input to close figures and exit")
+     input("\nWaiting for input to close figures and exit")
 
 
 3. Citations are included using the standard `Sphinx <https://www.sphinx-doc.org/en/master/>`__ ``:cite:`cite-key``` syntax, where ``cite-key`` is the key of an entry in ``docs/source/references.bib``.
@@ -237,28 +235,28 @@ and ``scico-data`` repositories must be updated and kept in sync.
 
 4. Change directory to the ``data`` directory and add/commit the new Jupyter Notebook:
 
-::
+   ::
 
-   cd scico/data
-   git add notebooks/new_example.ipynb
-   git commit -m "Add new usage example"
+      cd scico/data
+      git add notebooks/new_example.ipynb
+      git commit -m "Add new usage example"
 
 
 5. Return to the main SCICO repository, ensure the ``main`` branch is checked out, add/commit the new script and updated submodule:
 
-::
+   ::
 
-   cd ..  # pwd now `scico` repo root
-   git add data
-   git add examples/scripts/new_filename.py
-   git commit -m "Add usage example and update data module"
+      cd ..  # pwd now `scico` repo root
+      git add data
+      git add examples/scripts/new_filename.py
+      git commit -m "Add usage example and update data module"
 
 
 6.  Push both repositories:
 
-::
+   ::
 
-  git submodule foreach --recursive 'git push' && git push
+      git submodule foreach --recursive 'git push' && git push
 
 
 Adding New Data
@@ -273,28 +271,28 @@ scico-data repositories must be updated and kept in sync.
 
 1. Add the ``new_data.npz`` file to the ``scico/data`` directory.
 
-2.  Navigate to the ``data`` directory and add/commit the new data file:
+2. Navigate to the ``data`` directory and add/commit the new data file:
 
-::
+   ::
 
-   cd scico/data
-   git add new_data.npz
-   git commit -m "Add new data file"
+      cd scico/data
+      git add new_data.npz
+      git commit -m "Add new data file"
 
 3.  Return to the base SCICO repository, ensure the ``main`` branch is checked out, add/commit the new data and update submodule:
 
-::
+   ::
 
-   cd ..  # pwd now `scico` repo root
-   git checkout main
-   git add data
-   git commit -m "Add data and update data module"
+      cd ..  # pwd now `scico` repo root
+      git checkout main
+      git add data
+      git commit -m "Add data and update data module"
 
 4.  Push both repositories:
 
-::
+   ::
 
-  git submodule foreach --recursive 'git push' && git push
+      git submodule foreach --recursive 'git push' && git push
 
 
 Tests

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -38,55 +38,66 @@ respositories in your own git account.
 
 2. Make sure that you have python >= 3.8 installed in order to create a conda virtual environment.
 
-3. To create a conda virtual environment, clone your fork from the source repo.
-To create a clone of scico that includes the scico-data submodule:
+3. Clone your fork from the source repo.
 
    ::
 
       git clone --recurse-submodules git@github.com:<username>/scico.git
 
-4. Add the SCICO repo as an upstream remote to sync your changes:
+
+4. Create a conda environment using Python >= 3.8:
 
    ::
 
-      git remote add upstream https://www.github.com/lanl/scico
-
-5. After adding the upstream, the recommended way to install SCICO and its dependencies is via `conda <https://docs.conda.io/en/latest/>`_ using the scripts in ``misc/conda``:
-
-  - ``install_conda.sh``: install ``miniconda``
-    (needed if conda is not already installed on your system).
-  - ``conda_env.sh``: install a ``conda`` environment
-    with all SCICO dependencies. For GPU installation, see ``conda_env.sh -h``.
+      conda create -n scico python=3.8
 
 
-6. Activate the created conda virtual environment:
+5. Activate the created conda virtual environment:
 
    ::
 
-      conda activate py38
+      conda activate scico 
 
 
-7. Navigate to the root of the cloned repository:
+6. Navigate to the root of the cloned repository:
 
    ::
 
       cd scico
 
-8. Once dependencies have been installed, install SCICO in editable form:
+
+7. Add the SCICO repo as an upstream remote to sync your changes:
+
+   ::
+
+      git remote add upstream https://www.github.com/lanl/scico
+
+
+8. After adding the upstream, the recommended way to install SCICO and its dependencies is via pip:
+
+   ::
+
+      pip install -r requirements.txt  # Installs basic requirements
+      pip install -r docs/docs_requirements.txt # Installs documentation requirements
+      pip install -r examples/examples_requirements.txt # Installs example requirements
+      pip install -e .  # Installs SCICO from the current directory in editable mode
+
+
+9. Once dependencies have been installed, install SCICO in editable form:
 
    ::
 
       pip install -e .
 
 
-9. Set up ``black`` and ``isort`` pre-commit hooks:
+10. Set up ``black`` and ``isort`` pre-commit hooks:
 
    ::
 
       pre-commit install  # Sets up git pre-commit hooks
 
 
-10. For testing see `Tests`_.
+11. For testing see `Tests`_.
 
 
 Contributing Code
@@ -114,7 +125,7 @@ A feature development workflow might look like this:
 
    ::
 
-      git checkout -b name-of-change
+      git checkout -b <username>/<brief-description>
 
 
 4. Make your desired changes.
@@ -126,7 +137,7 @@ A feature development workflow might look like this:
 
       pytest
 
-   You can limit the test suite to a specific file:
+   You can limit the test suite to a specific file for example:
 
    ::
 
@@ -154,7 +165,7 @@ A feature development workflow might look like this:
 
    ::
 
-      git push --set-upstream origin name-of-change
+      git push --set-upstream origin <username>/<brief-description>
 
 
 9.  Create a new pull request to the ``main`` branch; see `the GitHub instructions <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,1 +1,0 @@
-../../INSTALL.rst

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -87,12 +87,6 @@ For Developers
 For installing a version of SCICO suitable for development,
 see the instructions in :ref:`scico_dev_contributing`.
 
-In the cloned repository root directory, set up the pre-commit hook:
-
-::
-
-   pre-commit install
-
 
 Building Documentation
 ----------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -84,9 +84,8 @@ not be separately installed.
 For Developers
 --------------
 
-The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_
-and `isort <https://pypi.org/project/isort/>`_ code formatting utilities.
-You can set up a `pre-commit hook <https://pre-commit.com>`_ to ensure any modified code passes format check before it is committed to the development repo.
+For installing a version of SCICO suitable for development,
+see the instructions in :ref:`scico_dev_contributing`.
 
 In the cloned repository root directory, set up the pre-commit hook:
 

--- a/docs/source/operator.rst
+++ b/docs/source/operator.rst
@@ -1,6 +1,5 @@
 Operators
 =========
-
 An operator is a map from :math:`\mathbb{R}^n` or :math:`\mathbb{C}^n`
 to :math:`\mathbb{R}^m` or :math:`\mathbb{C}^m`.
 In SCICO, operators are primarily used to represent imaging systems

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -35,7 +35,7 @@ Unicode variable names are allowed for internal usage (e.g. for Greek characters
 Naming
 ------
 
-Naming conventions for the different programming components are as follows:
+Naming conventions adhering to `google's naming conventions <https://google.github.io/styleguide/pyguide.html#3164-guidelines-derived-from-guidos-recommendations>`_ for the different programming components are as follows:
 
 .. list-table:: Naming Conventions
    :widths: 20 20
@@ -101,7 +101,7 @@ Things to avoid:
 Displaying and Printing Strings
 -------------------------------
 
-Prefer to use Python f-strings, rather than `.format` or `%` syntax.
+Prefer to use Python f-strings, rather than `.format` or `%` syntax as `google's string conventions <https://google.github.io/styleguide/pyguide.html#310-strings>`_ suggests.
 
 .. code:: Python
 
@@ -115,7 +115,7 @@ Prefer to use Python f-strings, rather than `.format` or `%` syntax.
 Imports
 -------
 
-Usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
+We adhere to `google's import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ which states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
 
 -  Use ``import x`` for importing packages and modules, where x is the package or module name.
 -  Use ``from x import y`` where x is the package name and y is the module name.
@@ -127,7 +127,7 @@ Usage of ``import`` statements should be reserved for packages and modules only 
 Variables
 ---------
 
-Apart from naming conventions there are a few extra documentation and coding practices that can be applied to variables such as:
+Apart from naming conventions `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
 
 - One may type a variables by using a ``: type`` before the function value is assigned, e.g.,
 
@@ -143,7 +143,7 @@ Apart from naming conventions there are a few extra documentation and coding pra
 Parameters
 ----------
 
-There are three important stlyle components for parameters:
+There are three important stlyle components for parameters inspired by `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_:
 
 1. Typing
 
@@ -199,7 +199,7 @@ Docstrings are a way to document code within Python and it is the first statemen
 Typing
 ~~~~~~
 
-The following are docstring-specific usages that must be explained before going into the creation of said docstrings:
+The following are docstring-specific usages that `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_ suggests before going into the creation of said docstrings:
 
 - Always enclose variables in single backticks.
 - For the parameter types, be as precise as possible, do not use backticks.
@@ -208,7 +208,7 @@ The following are docstring-specific usages that must be explained before going 
 Modules
 ~~~~~~~
 
-Files must start with a docstring that describes the functionality of the module.
+According to `google's module conventions <https://google.github.io/styleguide/pyguide.html#382-modules>`_ files must start with a docstring that describes the functionality of the module.
 For example,
 
 .. code-block:: python
@@ -228,9 +228,9 @@ Functions
 ~~~~~~~~~
 
 The word *function* encompasses functions, methods, or generators in this section.
-The docstring should give enough information to make calls  to the function without needing to read the functions code.
+The docstring should give enough information to make calls to the function without needing to read the functions code.
 
-Functions should contain docstrings unless:
+`Google's function conventions <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ suggests that functions should contain docstrings unless:
 - not externally visible (the function name is prefaced with an underscore) or
 - very short.
 
@@ -289,7 +289,7 @@ Example:
 Classes
 ~~~~~~~
 
-Classes, like functions, should have a docstring below the definition describing the class and the class functionality. If the class contains public attributes the class should have an attributes section where each attribute is listed by name and followed by a description divided by a colon much like a function's args.
+Classes, like functions, should have a docstring below the definition describing the class and the class functionality adhering to `google's class conventions <https://google.github.io/styleguide/pyguide.html#384-classes>`_. If the class contains public attributes the class should have an attributes section where each attribute is listed by name and followed by a description divided by a colon much like a function's args.
 
 | Example:
 
@@ -318,7 +318,7 @@ Classes, like functions, should have a docstring below the definition describing
 Extra Sections
 ~~~~~~~~~~~~~~
 
-The following are sections that can be added to functions, modules, classes, or method definitions taken from the numpy style guide.
+The following are sections that can be added to functions, modules, classes, or method definitions taken from the `numpy style guide <https://numpydoc.readthedocs.io/en/latest/format.html#sections>`_.
 
 -  See Also:
 
@@ -407,7 +407,7 @@ Comments
 ~~~~~~~~
 
 There are two types of comments: *block* and *inline*. A good rule of thumb to follow for when to include a comment in your code is *if you have to explain it or is too hard to figure out at first glance, then comment it*.
-An example of this is complicated operations which most likely require a block of comments beforehand.
+An example of this taken from `google's comment conventions <https://google.github.io/styleguide/pyguide.html#385-block-and-inline-comments>`_ is complicated operations which most likely require a block of comments beforehand.
 
 .. code-block:: Python
 

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -115,7 +115,7 @@ Prefer to use Python f-strings, rather than `.format` or `%` syntax as `google's
 Imports
 -------
 
-We adhere to `google's import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ which states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
+`Google's import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
 
 -  Use ``import x`` for importing packages and modules, where x is the package or module name.
 -  Use ``from x import y`` where x is the package name and y is the module name.
@@ -127,7 +127,7 @@ We adhere to `google's import conventions <https://google.github.io/styleguide/p
 Variables
 ---------
 
-Apart from naming conventions `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
+Apart from naming conventions, `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
 
 - One may type a variables by using a ``: type`` before the function value is assigned, e.g.,
 
@@ -143,7 +143,7 @@ Apart from naming conventions `google's variable typing conventions <https://goo
 Parameters
 ----------
 
-There are three important stlyle components for parameters inspired by `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_:
+There are three important style components for parameters inspired by `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_:
 
 1. Typing
 

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -152,10 +152,10 @@ There are three important style components for parameters inspired by the `NumPy
    From the ``typing`` module we can use more types such as ``Optional``, ``Union``, and ``Any``.
    For example,
 
-      .. code-block:: python
+   .. code-block:: python
 
-	 def foo(a: str) -> str:
-	    """Takes an input of type string and returns a value of type string"""
+      def foo(a: str) -> str:
+         """Takes an input of type string and returns a value of type string"""
 	    ...
 
 2. Default Values
@@ -166,12 +166,12 @@ There are three important style components for parameters inspired by the `NumPy
    those values can be listed in braces, with the default appearing first.
    For example,
 
-      .. code-block:: python
+   .. code-block:: python
 
-	 """
-	 letters: {'A', 'B, 'C'}
-	     Description of `letters`.
-	 """
+      """
+      letters: {'A', 'B, 'C'}
+         Description of `letters`.
+      """
 
 3. NoneType
 
@@ -182,10 +182,10 @@ There are three important style components for parameters inspired by the `NumPy
    ``Optional[T]`` is preferred over ``Union[T, None]``.
    For example,
 
-      .. code-block:: python
+   .. code-block:: python
 
-	 def foo(a: Optional[str], b: Optional[Union[str, int]]) -> str:
-	    ...
+      def foo(a: Optional[str], b: Optional[Union[str, int]]) -> str:
+	 ...
 
    For documentation purposes, ``NoneType`` or ``None`` should be written with double backticks.
 
@@ -325,23 +325,23 @@ The following are sections that can be added to functions, modules, classes, or 
    - Refers to related code. Used to direct users to other modules, functions, or classes that they may not be aware of.
    - When referring to functions in the same sub-module, no prefix is needed. Example: For ``numpy.mean`` inside the same sub-module:
 
-	.. code-block:: python
+     .. code-block:: python
 
-	    """
-	    See Also
-	    --------
-	    average: Weighted average.
-	    """
+	"""
+	See Also
+	--------
+	average: Weighted average.
+	"""
 
    - For a reference to ``fft`` in another module:
 
-	.. code-block:: python
+     .. code-block:: python
 
-	   """
-	   See Also
-	   --------
-	   fft.fft2: 2-D fast discrete Fourier transform.
-	   """
+	"""
+        See Also
+        --------
+        fft.fft2: 2-D fast discrete Fourier transform.
+        """
 
 -  Notes
 

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -27,7 +27,7 @@ We adhere to `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ with the except
 
 We aim to incorporate `PEP 526 <https://www.python.org/dev/peps/pep-0484/>`_ type annotations throughout the library.  See the `Mypy <https://mypy.readthedocs.io/en/stable/>`_ type annotation `cheat sheet <https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html>`_ for usage examples. Custom types are defined in :mod:`.typing`.
 
-Our coding conventions are based on both the `numpy conventions <https://numpydoc.readthedocs.io/en/latest/format.html#overview>`_ and the `google docstring conventions <https://google.github.io/styleguide/pyguide.html>`_.
+Our coding conventions are based on both the `NumPy conventions <https://numpydoc.readthedocs.io/en/latest/format.html#overview>`_ and the `Google docstring conventions <https://google.github.io/styleguide/pyguide.html>`_.
 
 Unicode variable names are allowed for internal usage (e.g. for Greek characters for mathematical symbols), but not as part of the public interface for functions or methods.
 
@@ -35,7 +35,7 @@ Unicode variable names are allowed for internal usage (e.g. for Greek characters
 Naming
 ------
 
-Naming conventions adhering to `google's naming conventions <https://google.github.io/styleguide/pyguide.html#3164-guidelines-derived-from-guidos-recommendations>`_ for the different programming components are as follows:
+Naming conventions adhering to the `Google naming conventions <https://google.github.io/styleguide/pyguide.html#3164-guidelines-derived-from-guidos-recommendations>`_ for the different programming components are as follows:
 
 .. list-table:: Naming Conventions
    :widths: 20 20
@@ -101,7 +101,7 @@ Things to avoid:
 Displaying and Printing Strings
 -------------------------------
 
-Prefer to use Python f-strings, rather than `.format` or `%` syntax as `google's string conventions <https://google.github.io/styleguide/pyguide.html#310-strings>`_ suggests.
+Prefer to use Python f-strings, rather than `.format` or `%` syntax as the `Google string conventions <https://google.github.io/styleguide/pyguide.html#310-strings>`_ suggests.
 
 .. code:: Python
 
@@ -115,7 +115,7 @@ Prefer to use Python f-strings, rather than `.format` or `%` syntax as `google's
 Imports
 -------
 
-`Google's import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
+The `Google import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
 
 -  Use ``import x`` for importing packages and modules, where x is the package or module name.
 -  Use ``from x import y`` where x is the package name and y is the module name.
@@ -127,7 +127,7 @@ Imports
 Variables
 ---------
 
-Apart from naming conventions, `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#3198-typing-variables>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
+Apart from naming conventions, the `Google variable typing conventions <https://google.github.io/styleguide/pyguide.html#3198-typing-variables>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
 
 - One may type a variables by using a ``: type`` before the function value is assigned, e.g.,
 
@@ -143,7 +143,7 @@ Apart from naming conventions, `google's variable typing conventions <https://go
 Parameters
 ----------
 
-There are three important style components for parameters inspired by `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_:
+There are three important style components for parameters inspired by the `NumPy parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_:
 
 1. Typing
 
@@ -177,7 +177,7 @@ There are three important style components for parameters inspired by `numpy's p
    In Python, ``NoneType`` is a first-class type, meaning the type itself
    can be passed into and returned from functions.
    ``None`` is the most commonly used alias for ``NoneType``.
-   If any of a function's parameters can be ``None`` then it has to be declared.
+   If any of the parameters of a function can be ``None`` then it has to be declared.
    ``Optional[T]`` is preferred over ``Union[T, None]``.
    For example,
 
@@ -199,7 +199,7 @@ Docstrings are a way to document code within Python and it is the first statemen
 Typing
 ~~~~~~
 
-The following are docstring-specific usages that `numpy's parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_ suggests before going into the creation of said docstrings:
+The following are docstring-specific usages that the `NumPy parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_ suggests before going into the creation of said docstrings:
 
 - Always enclose variables in single backticks.
 - For the parameter types, be as precise as possible, do not use backticks.
@@ -208,7 +208,7 @@ The following are docstring-specific usages that `numpy's parameter conventions 
 Modules
 ~~~~~~~
 
-According to `google's module conventions <https://google.github.io/styleguide/pyguide.html#382-modules>`_ files must start with a docstring that describes the functionality of the module.
+According to the `Google module conventions <https://google.github.io/styleguide/pyguide.html#382-modules>`_ files must start with a docstring that describes the functionality of the module.
 For example,
 
 .. code-block:: python
@@ -230,7 +230,7 @@ Functions
 The word *function* encompasses functions, methods, or generators in this section.
 The docstring should give enough information to make calls to the function without needing to read the functions code.
 
-`Google's function conventions <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ suggests that functions should contain docstrings unless:
+The `Google function conventions <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ suggests that functions should contain docstrings unless:
 - not externally visible (the function name is prefaced with an underscore) or
 - very short.
 
@@ -289,7 +289,7 @@ Example:
 Classes
 ~~~~~~~
 
-Classes, like functions, should have a docstring below the definition describing the class and the class functionality adhering to `google's class conventions <https://google.github.io/styleguide/pyguide.html#384-classes>`_. If the class contains public attributes the class should have an attributes section where each attribute is listed by name and followed by a description divided by a colon much like a function's args.
+Classes, like functions, should have a docstring below the definition describing the class and the class functionality adhering to the `Google class conventions <https://google.github.io/styleguide/pyguide.html#384-classes>`_. If the class contains public attributes, the class should have an attributes section where each attribute is listed by name and followed by a description, separated by a colon, like for function parameters.
 
 | Example:
 
@@ -318,7 +318,7 @@ Classes, like functions, should have a docstring below the definition describing
 Extra Sections
 ~~~~~~~~~~~~~~
 
-The following are sections that can be added to functions, modules, classes, or method definitions taken from the `numpy style guide <https://numpydoc.readthedocs.io/en/latest/format.html#sections>`_.
+The following are sections that can be added to functions, modules, classes, or method definitions taken from the `NumPy style guide <https://numpydoc.readthedocs.io/en/latest/format.html#sections>`_.
 
 -  See Also:
 
@@ -407,7 +407,7 @@ Comments
 ~~~~~~~~
 
 There are two types of comments: *block* and *inline*. A good rule of thumb to follow for when to include a comment in your code is *if you have to explain it or is too hard to figure out at first glance, then comment it*.
-An example of this, taken from `google's comment conventions <https://google.github.io/styleguide/pyguide.html#385-block-and-inline-comments>`_, is complicated operations which most likely require a block of comments beforehand.
+An example of this, taken from the `Google comment conventions <https://google.github.io/styleguide/pyguide.html#385-block-and-inline-comments>`_, is complicated operations which most likely require a block of comments beforehand.
 
 .. code-block:: Python
 

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -41,7 +41,7 @@ Unicode variable names are allowed for internal usage (e.g. for Greek characters
 Naming
 ------
 
-Naming conventions adhering to the `Google naming conventions <https://google.github.io/styleguide/pyguide.html#3164-guidelines-derived-from-guidos-recommendations>`_ for the different programming components are as follows:
+We follow the `Google naming conventions <https://google.github.io/styleguide/pyguide.html#3164-guidelines-derived-from-guidos-recommendations>`_ listed here:
 
 .. list-table:: Naming Conventions
    :widths: 20 20
@@ -106,7 +106,7 @@ Things to avoid:
 Displaying and Printing Strings
 -------------------------------
 
-Prefer to use Python f-strings, rather than `.format` or `%` syntax as the `Google string conventions <https://google.github.io/styleguide/pyguide.html#310-strings>`_ suggests.
+We follow the `Google string conventions <https://google.github.io/styleguide/pyguide.html#310-strings>`_. Notably, prefer to use Python f-strings, rather than `.format` or `%` syntax. For example:
 
 .. code:: Python
 
@@ -118,7 +118,7 @@ Prefer to use Python f-strings, rather than `.format` or `%` syntax as the `Goog
 Imports
 -------
 
-The `Google import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ states that the usage of ``import`` statements should be reserved for packages and modules only and not individual classes or functions. The only exception to this is the typing module.
+We follow the `Google import conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_. The usage of ``import`` statements should be reserved for packages and modules only excluding individual classes and functions. The only exception to this is the typing module.
 
 -  Use ``import x`` for importing packages and modules, where x is the package or module name.
 -  Use ``from x import y`` where x is the package name and y is the module name.
@@ -129,7 +129,7 @@ The `Google import conventions <https://google.github.io/styleguide/pyguide.html
 Variables
 ---------
 
-Apart from naming conventions, the `Google variable typing conventions <https://google.github.io/styleguide/pyguide.html#3198-typing-variables>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
+We follow the `Google variable typing conventions <https://google.github.io/styleguide/pyguide.html#3198-typing-variables>`_ which states that there are a few extra documentation and coding practices that can be applied to variables such as:
 
 - One may type a variables by using a ``: type`` before the function value is assigned, e.g.,
 
@@ -199,7 +199,7 @@ Docstrings are a way to document code within Python and it is the first statemen
 Typing
 ~~~~~~
 
-The following are docstring-specific usages that the `NumPy parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_ suggests before going into the creation of said docstrings:
+We follow the `NumPy parameter conventions <https://numpydoc.readthedocs.io/en/latest/format.html#parameters>`_. The following are docstring-specific usages:
 
 - Always enclose variables in single backticks.
 - For the parameter types, be as precise as possible, do not use backticks.
@@ -208,8 +208,7 @@ The following are docstring-specific usages that the `NumPy parameter convention
 Modules
 ~~~~~~~
 
-According to the `Google module conventions <https://google.github.io/styleguide/pyguide.html#382-modules>`_ files must start with a docstring that describes the functionality of the module.
-For example,
+We follow the `Google module conventions <https://google.github.io/styleguide/pyguide.html#382-modules>`_. Notably, files must start with a docstring that describes the functionality of the module. For example,
 
 .. code-block:: python
 
@@ -224,13 +223,14 @@ For example,
     bar = foo.FunctionBar()
     """"
 
+
 Functions
 ~~~~~~~~~
 
 The word *function* encompasses functions, methods, or generators in this section.
 The docstring should give enough information to make calls to the function without needing to read the functions code.
 
-The `Google function conventions <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ suggests that functions should contain docstrings unless:
+We follow the `Google function conventions <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_. Notably, functions should contain docstrings unless:
 - not externally visible (the function name is prefaced with an underscore) or
 - very short.
 
@@ -289,7 +289,7 @@ Example:
 Classes
 ~~~~~~~
 
-Classes, like functions, should have a docstring below the definition describing the class and the class functionality adhering to the `Google class conventions <https://google.github.io/styleguide/pyguide.html#384-classes>`_. If the class contains public attributes, the class should have an attributes section where each attribute is listed by name and followed by a description, separated by a colon, like for function parameters.
+We follow the `Google class conventions <https://google.github.io/styleguide/pyguide.html#384-classes>`_. Classes, like functions, should have a docstring below the definition describing the class and the class functionality. If the class contains public attributes, the class should have an attributes section where each attribute is listed by name and followed by a description, separated by a colon, like for function parameters. For example,
 
 | Example:
 
@@ -318,7 +318,7 @@ Classes, like functions, should have a docstring below the definition describing
 Extra Sections
 ~~~~~~~~~~~~~~
 
-The following are sections that can be added to functions, modules, classes, or method definitions taken from the `NumPy style guide <https://numpydoc.readthedocs.io/en/latest/format.html#sections>`_.
+We follow the `NumPy style guide <https://numpydoc.readthedocs.io/en/latest/format.html#sections>`_. Notably, the following are sections that can be added to functions, modules, classes, or method definitions.
 
 -  See Also:
 

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -17,6 +17,12 @@ Style Guide
       list-style: square outside !important;
       margin-left: 1em !important;
     }
+    section {
+      padding-bottom: 1em;
+    }
+    ul {
+      margin-bottom: 1em;
+    }
     </style>
 
 
@@ -96,7 +102,6 @@ Things to avoid:
    - protected: Use a single underscore, ``_``, for protected access; and
    - pseudo-private: Use double underscores, ``_``, for pseudo-private access via name mangling.
 
-|
 
 Displaying and Printing Strings
 -------------------------------
@@ -110,8 +115,6 @@ Prefer to use Python f-strings, rather than `.format` or `%` syntax as the `Goog
     print(f"The state is {state}")  # Preferred
 
 
-
-
 Imports
 -------
 
@@ -122,7 +125,6 @@ The `Google import conventions <https://google.github.io/styleguide/pyguide.html
 -  Use ``from x import y as z`` if two modules named ``y`` are imported or if ``y`` is too long of a name.
 -  Use ``import y as z`` when ``z`` is a standard abbreviation like ``import numpy as np``.
 
-|
 
 Variables
 ---------
@@ -138,7 +140,6 @@ Apart from naming conventions, the `Google variable typing conventions <https://
 - Avoid global variables.
 - A function can refer to variables defined in enclosing functions but cannot assign to them.
 
-|
 
 Parameters
 ----------
@@ -188,7 +189,6 @@ There are three important style components for parameters inspired by the `NumPy
 
    For documentation purposes, ``NoneType`` or ``None`` should be written with double backticks.
 
-|
 
 Docstrings
 ----------
@@ -420,8 +420,10 @@ An example of this, taken from the `Google comment conventions <https://google.g
 
 If a comment consists of one or more full sentences (as is typically the case for *block* comments), it should start with an upper case letter and end with a period. *Inline* comments often consist of a brief phrase which is not a full sentence, in which case they should have a lower case initial letter and not have a terminating period.
 
+
 Documentation Pages
 -------------------
+
 Documentation that is separate from code (like this page)
 should follow the
 `IEEE Style Manual

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -127,7 +127,7 @@ Imports
 Variables
 ---------
 
-Apart from naming conventions, `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#22-imports>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
+Apart from naming conventions, `google's variable typing conventions <https://google.github.io/styleguide/pyguide.html#3198-typing-variables>`_ suggests that there are a few extra documentation and coding practices that can be applied to variables such as:
 
 - One may type a variables by using a ``: type`` before the function value is assigned, e.g.,
 
@@ -407,7 +407,7 @@ Comments
 ~~~~~~~~
 
 There are two types of comments: *block* and *inline*. A good rule of thumb to follow for when to include a comment in your code is *if you have to explain it or is too hard to figure out at first glance, then comment it*.
-An example of this taken from `google's comment conventions <https://google.github.io/styleguide/pyguide.html#385-block-and-inline-comments>`_ is complicated operations which most likely require a block of comments beforehand.
+An example of this, taken from `google's comment conventions <https://google.github.io/styleguide/pyguide.html#385-block-and-inline-comments>`_, is complicated operations which most likely require a block of comments beforehand.
 
 .. code-block:: Python
 

--- a/scico/_generic_operators.py
+++ b/scico/_generic_operators.py
@@ -29,11 +29,24 @@ from scico.typing import BlockShape, DType, JaxArray, Shape
 from scico.util import is_nested
 
 
-# Wrapper function for defining mul, rmul, truediv between a scalar and a Operator
-# If one of these binary operations are called in the form binop(Operator, other)
-# and 'b' is a scalar, specialized Operator constructors can be called.
-# Otherwise, if other is not a scalar, an exception is raised
 def _wrap_mul_div_scalar(func):
+    r"""Wrapper function for defining mul, rmul, and truediv
+    between a scalar and an Operator.
+
+    If one of these binary operations are called in the form
+    binop(Operator, other) and 'b' is a scalar, specialized
+    Operator constructors can be called.
+
+    Args:
+        func: should be either .__mul__(), .__rmul__(),
+        or .__truediv__().
+
+    Raises:
+        TypeError: A binop with the form binop(Operator, other) is
+        called and other is not a scalar.
+
+    """
+
     @wraps(func)
     def wrapper(a, b):
         if np.isscalar(b) or isinstance(b, jax.core.Tracer):
@@ -330,15 +343,24 @@ output_dtype : {self.output_dtype}
         )
 
 
-# Wrapper function for defining __add__, __sub__ between LinearOperator and other objects
-# Handles shape checking and dispatching based on operand types.
-# If one of the two operands is an Operator, an Operator is returned.
-# If both operands are LinearOperators of different types, a generic LinearOperator is returned.
-# If both operands are LinearOperators of the same type, a special constructor can be called
-#    see, eg, Convolve.__add__
 def _wrap_add_sub(func: Callable, op: Callable) -> Callable:
-    # func should be either .__add__() or .__sub__()
-    # op should be the functional equivalent of the same (op.add for func = __add__)
+    r"""Wrapper function for defining __add__, __sub__ between LinearOperator and other objects.
+
+    Handles shape checking and dispatching based on operand types:
+    - If one of the two operands is an Operator, an Operator is returned.
+    - If both operands are LinearOperators of different types, a generic LinearOperator is returned.
+    - If both operands are LinearOperators of the same type, a special constructor can be called
+
+    Args:
+        func: should be either .__add__() or .__sub__().
+        op: functional equivalent of func, ex. op.add for func = __add__.
+
+    Raises:
+        ValueError: The shape of both operators does not match.
+        TypeError: One of the two operands is not an Operator or LinearOperator.
+
+    """
+
     @wraps(func)
     def wrapper(
         a: LinearOperator, b: Union[Operator, LinearOperator]

--- a/scico/_generic_operators.py
+++ b/scico/_generic_operators.py
@@ -344,20 +344,26 @@ output_dtype : {self.output_dtype}
 
 
 def _wrap_add_sub(func: Callable, op: Callable) -> Callable:
-    r"""Wrapper function for defining __add__, __sub__ between LinearOperator and other objects.
+    r"""Wrapper function for defining __add__, __sub__ between
+    LinearOperator and other objects.
 
     Handles shape checking and dispatching based on operand types:
-    - If one of the two operands is an Operator, an Operator is returned.
-    - If both operands are LinearOperators of different types, a generic LinearOperator is returned.
-    - If both operands are LinearOperators of the same type, a special constructor can be called
+    - If one of the two operands is an Operator, an Operator is
+    returned.
+    - If both operands are LinearOperators of different types,
+    a generic LinearOperator is returned.
+    - If both operands are LinearOperators of the same type,
+    a special constructor can be called
 
     Args:
         func: should be either .__add__() or .__sub__().
-        op: functional equivalent of func, ex. op.add for func = __add__.
+        op: functional equivalent of func, ex. op.add for func =
+        __add__.
 
     Raises:
         ValueError: The shape of both operators does not match.
-        TypeError: One of the two operands is not an Operator or LinearOperator.
+        TypeError: One of the two operands is not an Operator
+        or LinearOperator.
 
     """
 

--- a/scico/_generic_operators.py
+++ b/scico/_generic_operators.py
@@ -30,8 +30,10 @@ from scico.util import is_nested
 
 
 def _wrap_mul_div_scalar(func):
-    r"""Wrapper function for defining mul, rmul, and truediv
-    between a scalar and an Operator.
+    r"""Wrapper function for defining mul, rmul, and truediv.
+
+    Wrapper function for defining mul, rmul, and truediv between a scalar
+    and an Operator.
 
     If one of these binary operations are called in the form
     binop(Operator, other) and 'b' is a scalar, specialized
@@ -39,12 +41,11 @@ def _wrap_mul_div_scalar(func):
 
     Args:
         func: should be either .__mul__(), .__rmul__(),
-        or .__truediv__().
+           or .__truediv__().
 
     Raises:
         TypeError: A binop with the form binop(Operator, other) is
         called and other is not a scalar.
-
     """
 
     @wraps(func)
@@ -344,21 +345,22 @@ output_dtype : {self.output_dtype}
 
 
 def _wrap_add_sub(func: Callable, op: Callable) -> Callable:
-    r"""Wrapper function for defining __add__, __sub__ between
-    LinearOperator and other objects.
+    r"""Wrapper function for defining __add__, __sub__.
+
+    Wrapper function for defining __add__, __sub__ between LinearOperator
+    and other objects.
 
     Handles shape checking and dispatching based on operand types:
-    - If one of the two operands is an Operator, an Operator is
-    returned.
-    - If both operands are LinearOperators of different types,
-    a generic LinearOperator is returned.
-    - If both operands are LinearOperators of the same type,
-    a special constructor can be called
+    - If one of the two operands is an Operator, an Operator is returned.
+    - If both operands are LinearOperators of different types, a generic
+      LinearOperator is returned.
+    - If both operands are LinearOperators of the same type, a special
+      constructor can be called
 
     Args:
         func: should be either .__add__() or .__sub__().
         op: functional equivalent of func, ex. op.add for func =
-        __add__.
+           __add__.
 
     Raises:
         ValueError: The shape of both operators does not match.


### PR DESCRIPTION
This PR addresses the todos in the contributing, style, and operators sections of the documentation. Makes the install a fork tutorial instead, adds references to style guides used, and creates docstrings for marked wrapper methods. 

It is still a draft waiting for some edits in the installation section. 