### PR TITLE
Pin jax version and update pip install instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -70,22 +70,23 @@ GPU Enabled
 
 By default, ``pip install -r requirements.txt`` will install a CPU-only version of SCICO. To install a version with GPU support:
 
-1. Clone the repository
+1. Follow the CPU Only instructions, above
 
-2. Navigate to the repository root directory
-
-   ::
-
-      cd scico
-
-3. Install `JAX with GPU support <https://github.com/google/jax#installation>`_.
-
-4. Install remaining dependencies
+2. Identify which version of `jaxlib` was installed
 
    ::
 
-      pip install -r requirements.txt
+      pip list | grep jaxlib
 
+3. Install the same version of jaxlib, but with GPU support.
+   For help with this, see `JAX with GPU support <https://github.com/google/jax#installation>`_.
+   The command will be something like
+
+   ::
+      
+      pip install --upgrade "jaxlib==0.1.70+cuda110" -f https://storage.googleapis.com/jax-releases/jax_releases.html
+
+      
 
 Additional Dependencies for Tomography
 ######################################

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -72,7 +72,7 @@ By default, ``pip install -r requirements.txt`` will install a CPU-only version 
 
 1. Follow the CPU Only instructions, above
 
-2. Identify which version of `jaxlib` was installed
+2. Identify which version of jaxlib was installed
 
    ::
 
@@ -83,10 +83,10 @@ By default, ``pip install -r requirements.txt`` will install a CPU-only version 
    The command will be something like
 
    ::
-      
+
       pip install --upgrade "jaxlib==0.1.70+cuda110" -f https://storage.googleapis.com/jax-releases/jax_releases.html
 
-      
+
 
 Additional Dependencies for Tomography
 ######################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy>=1.12
 scipy>=0.19.1
 imageio
 matplotlib
-jax>=0.2.19
-jaxlib>=0.1.70
+jax == 0.2.19
+jaxlib == 0.1.70
 flax
 bm3d
 svmbir

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy>=1.12
 scipy>=0.19.1
 imageio
 matplotlib
-jax == 0.2.19
-jaxlib == 0.1.70
+jax==0.2.19
+jaxlib==0.1.70
 flax
 bm3d
 svmbir


### PR DESCRIPTION
These were the changes needed to get a GPU install of SCICO working on toro. Partially addresses #44 in that it pins the jax version but doesn't set up a build matrix to test SCICO with multiple versions of jax. Also updates instructions.