### PR TITLE
Add tests for DnCNN

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,7 +39,7 @@ jobs:
           pip install -r dev_requirements.txt
           pip install -e .
       - name: Run tests with pytest
-        run: pytest --cov=./ --cov-report=xml
+        run: pytest --cov=scico --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/scico/functional/_flax.py
+++ b/scico/functional/_flax.py
@@ -33,7 +33,7 @@ class FlaxMap(Functional):
 
         Args:
             model : Flax model to apply.
-            variables : parameters and batch stats of trained model.
+            variables : Parameters and batch stats of trained model.
         """
         self.model = model
         self.variables = variables
@@ -42,9 +42,15 @@ class FlaxMap(Functional):
     def prox(self, x: JaxArray, lam: float = 1) -> JaxArray:
         r"""Apply trained flax model.
 
+        *Warning*: The ``lam`` parameter is ignored, and has no effect on
+        the output.
+
         Args:
             x : input.
-            lam : noise estimate (not used).
+            lam : noise estimate (ignored).
+
+        Returns:
+            Output of flax model.
         """
         if isinstance(x, BlockArray):
             raise NotImplementedError

--- a/scico/functional/_flax.py
+++ b/scico/functional/_flax.py
@@ -9,7 +9,6 @@
 
 from typing import Any, Callable
 
-import scico.numpy as snp
 from flax import linen as nn
 from scico.blockarray import BlockArray
 from scico.typing import JaxArray
@@ -60,9 +59,10 @@ class FlaxMap(Functional):
             # flax works on (KxNxNxC) arrays
             # (generally KxHxWxC arrays)
             # K: input dim
+            x_shape = x.shape
             if x.ndim == 2:
                 x = x.reshape((1,) + x.shape + (1,))
             elif x.ndim == 3:
                 x = x.reshape((1,) + x.shape)
             y = self.model.apply(self.variables, x, train=False, mutable=False)
-            return snp.squeeze(y)
+            return y.reshape(x_shape)

--- a/scico/functional/_flax.py
+++ b/scico/functional/_flax.py
@@ -54,11 +54,11 @@ class FlaxMap(Functional):
         if isinstance(x, BlockArray):
             raise NotImplementedError
         else:
-            # add input singleton
-            # scico works on (NxN) or (NxNxC) arrays
-            # flax works on (KxNxNxC) arrays
-            # (generally KxHxWxC arrays)
-            # K: input dim
+            # Add singleton to input as necessary:
+            #   scico typically works with (HxW) or (HxWxC) arrays
+            #   flax expects (KxHxWxC) arrays
+            #   H: spatial height  W: spatial width
+            #   K: batch size  C: channel size
             x_shape = x.shape
             if x.ndim == 2:
                 x = x.reshape((1,) + x.shape + (1,))

--- a/scico/test/linop/test_linop.py
+++ b/scico/test/linop/test_linop.py
@@ -454,14 +454,11 @@ def test_operator_norm():
     Inorm = linop.operator_norm(I)
     assert np.abs(Inorm - 1.0) < 1e-5
     key = jax.random.PRNGKey(12345)
-    d, key = randn((16,), dtype=np.float32, key=key)
-    D = linop.Diagonal(d)
-    Dnorm = linop.operator_norm(D)
-    assert np.abs(Dnorm - snp.abs(d).max()) < 1e-5
-    d, key = randn((16,), dtype=np.complex64, key=key)
-    D = linop.Diagonal(d)
-    Dnorm = linop.operator_norm(D)
-    assert np.abs(Dnorm - snp.abs(d.max())) < 1e-5
+    for dtype in [np.float32, np.complex64]:
+        d, key = randn((16,), dtype=dtype, key=key)
+        D = linop.Diagonal(d)
+        Dnorm = linop.operator_norm(D)
+        assert np.abs(Dnorm - snp.abs(d).max()) < 1e-5
 
 
 class SumTestObj:

--- a/scico/test/test_functional.py
+++ b/scico/test/test_functional.py
@@ -461,7 +461,7 @@ class TestDnCNN:
         key = None
         N = 32
         self.x, key = randn((N, N), key=key, dtype=np.float32)
-        self.x_rgb, key = randn((N, N, 3), key=key, dtype=np.float32)
+        self.x_mltchn, key = randn((N, N, 5), key=key, dtype=np.float32)
 
         self.f = functional.DnCNN()
 
@@ -472,10 +472,9 @@ class TestDnCNN:
         assert no_jit.dtype == np.float32
         assert jitted.dtype == np.float32
 
-    @pytest.mark.skip(reason="rgb support currently broken")
-    def test_prox_rgb(self):
-        no_jit = self.f.prox(self.x_rgb, 1.0)
-        jitted = jax.jit(self.f.prox)(self.x_rgb, 1.0)
+    def test_prox_mltchn(self):
+        no_jit = self.f.prox(self.x_mltchn, 1.0)
+        jitted = jax.jit(self.f.prox)(self.x_mltchn, 1.0)
         np.testing.assert_allclose(no_jit, jitted, rtol=1e-3)
         assert no_jit.dtype == np.float32
         assert jitted.dtype == np.float32

--- a/scico/test/test_functional.py
+++ b/scico/test/test_functional.py
@@ -37,7 +37,10 @@ def prox_solve(v, v0, f, alpha):
     initial point for the optimization."""
     fnc = lambda x: prox_func(x, v, f, alpha)
     fmn = minimize(
-        fnc, v0, method="Nelder-Mead", options={"maxiter": 1000, "xatol": 1e-9, "fatol": 1e-9},
+        fnc,
+        v0,
+        method="Nelder-Mead",
+        options={"maxiter": 1000, "xatol": 1e-9, "fatol": 1e-9},
     )
 
     return fmn.x.reshape(v.shape), fmn.fun


### PR DESCRIPTION
Minor clean up of related code, and add tests for DnCNN.

Addresses absence of tests referred to in #84. PR will be left in draft mode until DnCNN support for RGB images is fixed, at which point the corresponding test will be enabled (currently skipped).