### PR TITLE
Consistent notation for Hermitian conjugate

### DIFF
--- a/docs/source/notes.rst
+++ b/docs/source/notes.rst
@@ -150,7 +150,7 @@ As a concrete example, consider the function :math:`f(x) = \frac{1}{2}\norm{\mb{
 \mb{x}}_2^2` where :math:`\mb{A}` is a complex matrix. The gradient of :math:`f` is
 usually given :math:`(\nabla f)(\mb{x}) = \mb{A}^H \mb{A} \mb{x}`, where :math:`\mb{A}^H` is the
 conjugate transpose of :math:`\mb{A}`. Applying ``jax.grad`` to :math:`f` will yield
-:math:`(\mb{A}^H \mb{A} \mb{x})^*`, where :math:`*` denotes complex conjugation.
+:math:`(\mb{A}^H \mb{A} \mb{x})^*`, where :math:`\cdot^*` denotes complex conjugation.
 
 The following code demonstrates the use of ``jax.grad`` and :func:`scico.grad`:
 

--- a/scico/admm.py
+++ b/scico/admm.py
@@ -129,8 +129,8 @@ class LinearSubproblemSolver(SubproblemSolver):
     solution of the linear system
 
     .. math::
-        \left(A^* W A + \sum_{i=1}^N \rho_i C_i^* C_i \right) \mb{x}^{(k+1)} = \;
-        A^* W \mb{y} + \sum_{i=1}^N \rho_i C_i^* ( \mb{z}^{(k)}_i - \mb{u}^{(k)}_i) \;.
+        \left(A^H W A + \sum_{i=1}^N \rho_i C_i^H C_i \right) \mb{x}^{(k+1)} = \;
+        A^H W \mb{y} + \sum_{i=1}^N \rho_i C_i^H ( \mb{z}^{(k)}_i - \mb{u}^{(k)}_i) \;.
 
     Attributes:
         admm (:class:`.ADMM`): ADMM solver object to which the solver is attached.
@@ -197,7 +197,7 @@ class LinearSubproblemSolver(SubproblemSolver):
 
         .. math::
 
-            A^* W \mb{y} + \sum_{i=1}^N \rho_i C_i^* ( \mb{z}^{(k)}_i - \mb{u}^{(k)}_i) \;.
+            A^H W \mb{y} + \sum_{i=1}^N \rho_i C_i^H ( \mb{z}^{(k)}_i - \mb{u}^{(k)}_i) \;.
 
         Returns:
             Computed solution.

--- a/scico/loss.py
+++ b/scico/loss.py
@@ -154,7 +154,7 @@ class SquaredL2Loss(Loss):
     @property
     def hessian(self) -> linop.LinearOperator:
         r"""If ``self.A`` is a :class:`.LinearOperator`, returns a new :class:`.LinearOperator` corresponding
-        to Hessian :math:`\mathrm{A^*A}`.
+        to Hessian :math:`\mathrm{A^H A}`.
 
         Otherwise not implemented.
         """
@@ -238,7 +238,7 @@ class WeightedSquaredL2Loss(Loss):
     @property
     def hessian(self) -> linop.LinearOperator:
         r"""If ``self.A`` is a :class:`scico.linop.LinearOperator`, returns a
-        :class:`scico.linop.LinearOperator` corresponding to Hessian :math:`\mathrm{A^* W A}`.
+        :class:`scico.linop.LinearOperator` corresponding to Hessian :math:`\mathrm{A^H W A}`.
 
         Otherwise not implemented.
         """


### PR DESCRIPTION
In relevant equations, replace `A^*` with `A^H` to denote the Hermitian conjugate.