### PR TITLE
Skip test based on content of scico/data/examples

### DIFF
--- a/scico/test/test_data.py
+++ b/scico/test/test_data.py
@@ -12,9 +12,8 @@ skipif_reason = (
     "\nAnd after cloning run:\n\tgit submodule init && git submodule update.\n"
 )
 
-pytestmark = pytest.mark.skipif(
-    len(os.listdir(os.path.abspath("./data"))) == 0, reason=skipif_reason
-)
+examples = os.path.join(os.path.dirname(data.__file__), "examples")
+pytestmark = pytest.mark.skipif(len(os.listdir(examples)) == 0, reason=skipif_reason)
 
 
 class TestSet:

--- a/scico/test/test_data.py
+++ b/scico/test/test_data.py
@@ -13,7 +13,7 @@ skipif_reason = (
 )
 
 examples = os.path.join(os.path.dirname(data.__file__), "examples")
-pytestmark = pytest.mark.skipif(len(os.listdir(examples)) == 0, reason=skipif_reason)
+pytestmark = pytest.mark.skipif(not os.path.isdir(examples), reason=skipif_reason)
 
 
 class TestSet:


### PR DESCRIPTION
Skip test based on content of `scico/data/examples` rather than content of of `data` directory.

Still to be confirmed that this modified skip test still achieves the original goal of skipping the tests for `scico.data` when run within a cloned repo without the `scico-data` submodule present.

Resolves #98.