### PR TITLE
Rebuild examples

### DIFF
--- a/examples/scripts/ct_astra_weighted_tv_admm.py
+++ b/examples/scripts/ct_astra_weighted_tv_admm.py
@@ -137,7 +137,7 @@ where
 """
 lambda_weighted = 1.14e2
 
-weights = counts / Io  # scaled by Io to balance the data vs regularization term
+weights = jax.device_put(counts / Io)  # scaled by Io to balance the data vs regularization term
 f = loss.WeightedSquaredL2Loss(y=y, A=A, W=linop.Diagonal(weights))
 
 admm_weighted = ADMM(


### PR DESCRIPTION
Rebuilt all the examples on GPU. *Should* be warning-free, but another pair of eyes wouldn't hurt.