### PR TITLE
Allow specification of test vectors in scico.linop.valid_adjoint

### DIFF
--- a/scico/linop/_linop.py
+++ b/scico/linop/_linop.py
@@ -95,8 +95,8 @@ def valid_adjoint(
     A: LinearOperator,
     AT: LinearOperator,
     eps: Optional[float] = 1e-7,
-    x : Optional[JaxArray] = None,
-    y : Optional[JaxArray] = None,
+    x: Optional[JaxArray] = None,
+    y: Optional[JaxArray] = None,
     key: Optional[PRNGKey] = None,
 ) -> Union[bool, float]:
     r"""Check whether :class:`.LinearOperator` `AT` is the adjoint of `A`.


### PR DESCRIPTION
Allow specification of test vectors in `scico.linop.valid_adjoint` and clean up docstring.

Note that this PR is for a merge to `smajee/test-fix-astra`, not to `main`.