### PR TITLE
Bump jax version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy>=1.12
 scipy>=0.19.1
 imageio
 matplotlib
-jaxlib==0.1.70
-jax==0.2.19
+jaxlib==0.1.75
+jax==0.2.26
 flax
 bm3d
 svmbir>=0.2.6

--- a/scico/__init__.py
+++ b/scico/__init__.py
@@ -18,8 +18,8 @@ from ._autograd import grad, jacrev, linear_adjoint, value_and_grad
 # TODO remove this check as we get closer to release?
 import jax, jaxlib
 
-jax_ver_req = "0.2.19"
-jaxlib_ver_req = "0.1.70"
+jax_ver_req = "0.2.26"
+jaxlib_ver_req = "0.1.75"
 if jax.__version__ < jax_ver_req:
     raise Exception(
         f"SCICO {__version__} requires jax>={jax_ver_req}; got {jax.__version__}; "

--- a/scico/blockarray.py
+++ b/scico/blockarray.py
@@ -1226,8 +1226,8 @@ core.pytype_aval_mappings[BlockArray] = lambda x: x._aval
 core.raise_to_shaped_mappings[_AbstractBlockArray] = lambda _aval, _: _aval
 xla.pytype_aval_mappings[BlockArray] = lambda x: x._aval
 xla.canonicalize_dtype_handlers[BlockArray] = lambda x: x
-xla.device_put_handlers[BlockArray] = _block_array_device_put_handler
-xla.xla_result_handlers[_AbstractBlockArray] = _block_array_result_handler
+jax._src.dispatch.device_put_handlers[BlockArray] = _block_array_device_put_handler
+jax._src.dispatch.result_handlers[_AbstractBlockArray] = _block_array_result_handler
 xla.xla_shape_handlers[_AbstractBlockArray] = _block_array_shape_handler
 
 

--- a/scico/test/linop/test_diff.py
+++ b/scico/test/linop/test_diff.py
@@ -88,8 +88,6 @@ def test_eval_circular(shape_axes, input_dtype, jit):
     B = FiniteDifference(input_shape=input_shape, input_dtype=input_dtype, axes=axes, jit=jit)
     Bx = B @ x
 
-    print(Ax.shape)
-    print(Bx.shape)
     for ax_ind, ax in enumerate(A.axes):
         np.testing.assert_allclose(
             Ax[

--- a/scico/test/test_functional.py
+++ b/scico/test/test_functional.py
@@ -310,9 +310,10 @@ def test_scalar_vmap():
     def foo(c):
         return (c * f)(x)
 
-    c_list = snp.array([1.0, 2.0, 3.0])
+    c_list = [1.0, 2.0, 3.0]
     non_vmap = np.array([foo(c) for c in c_list])
-    vmapped = jax.vmap(foo)(c_list)
+
+    vmapped = jax.vmap(foo)(snp.array(c_list))
     np.testing.assert_allclose(non_vmap, vmapped)
 
 
@@ -477,10 +478,6 @@ class TestBM3D:
 
 
 class TestDnCNN:
-    import os
-
-    os.environ["XLA_FLAGS"] = "--xla_gpu_deterministic_reductions --xla_gpu_autotune_level=0"
-
     def setup(self):
         key = None
         N = 32

--- a/scico/test/test_operator.py
+++ b/scico/test/test_operator.py
@@ -151,9 +151,9 @@ def test_scale_vmap(testobj):
     def foo(c):
         return (c * A)(x)
 
-    c_list = snp.array([1.0, 2.0, 3.0])
+    c_list = [1.0, 2.0, 3.0]
     non_vmap = np.array([foo(c) for c in c_list])
-    vmapped = jax.vmap(foo)(c_list)
+    vmapped = jax.vmap(foo)(snp.array(c_list))
     np.testing.assert_allclose(non_vmap, vmapped)
 
 
@@ -167,7 +167,7 @@ def test_scale_pmap(testobj):
     c_list = np.random.randn(jax.device_count())
     non_pmap = np.array([foo(c) for c in c_list])
     pmapped = jax.pmap(foo)(c_list)
-    np.testing.assert_allclose(non_pmap, pmapped)
+    np.testing.assert_allclose(non_pmap, pmapped, rtol=1e-6)
 
 
 def test_freeze_3arg():

--- a/scico/test/test_random.py
+++ b/scico/test/test_random.py
@@ -68,7 +68,7 @@ def test_add_seed_adapter():
     # get back the split key
     _, key_a = fun_alt(seed=42)
     key_b, _ = jax.random.split(jax.random.PRNGKey(42), 2)
-    np.testing.assert_equal(key_a, key_b)
+    np.testing.assert_array_equal(key_a, key_b)
 
     # error when key and seed are specified
     with pytest.raises(Exception):


### PR DESCRIPTION
Mostly this involved adapting to the restructuring of `jax.xla`. But it also required:
- some reworking of `test_blockarray` because `median` was no longer happy being called on complex arrays.
- a change in `test_functional` because `[snp.isscalar(x) for x in a_1D_jax_array]` no longer returns `[True, True, ...]`. 

Tested on GPU.

Closes #127 