### PR TITLE
Add pylint to `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,10 @@ repos:
       language: python
       language_version:  python3
       types: [python]
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: python
+      language_version: python3
+      types: [python]
+      args: ['--disable=all', '--enable=missing-docstring']

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
+pylint
 pytest
 pytest-runner
 pre-commit

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,8 +82,7 @@ Installing a Development Version
       pip install -e .  # Installs SCICO from the current directory in editable mode
 
 
-9. The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_
-   and `isort <https://pypi.org/project/isort/>`_ code formatting utilities.
+9. The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_, `isort <https://pypi.org/project/isort/>`_ and `pylint <https://pylint.pycqa.org/en/latest/>`_ code formatting utilities.
    You should set up a `pre-commit hook <https://pre-commit.com>`_ to ensure
    any modified code passes format check before it is committed to the development repo:
 


### PR DESCRIPTION
Fixes #113 

Changes proposed by this PR can be summarized as follows :-

- Adds `pylint` to `.pre-commit-config.yaml` using instructions from the official pylint documentation [here](https://pylint.pycqa.org/en/latest/user_guide/pre-commit-integration.html) with appropriate flags from the [**`lint_optional.yml`**](https://github.com/lanl/scico/blob/main/.github/workflows/lint_optional.yml) file.
- Adds `pylint` to `dev_requirements.txt`.