### PR TITLE
Miscellaneous changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,4 @@ repos:
       language: python
       language_version: python3
       types: [python]
-      args: ['--disable=all', '--enable=missing-docstring']
+      args: ['--score=n', '--disable=all', '--enable=missing-docstring']

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Version 0.0.2   (unreleased)
 • Additional optimization algorithms: Linearized ADMM and PDHG.
 • Move optimization algorithms into ``optimize`` subpackage.
 • Additional iteration stats columns for iterative ADMM subproblem solvers.
-• Renamed "Primal Residual" to "Prml Residual" in iteration stats.
+• Renamed "Primal Rsdl" to "Prml Rsdl" in displayed iteration stats.
 • Bump pinned `jaxlib` and `jax` versions to 0.1.70 and 0.2.19 respectively.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Version 0.0.2   (unreleased)
 
 • Additional optimization algorithms: Linearized ADMM and PDHG.
 • Move optimization algorithms into ``optimize`` subpackage.
+• Additional iteration stats columns for iterative ADMM subproblem solvers.
+• Renamed "Primal Residual" to "Prim Residual" in iteration stats.
 • Bump pinned `jaxlib` and `jax` versions to 0.1.70 and 0.2.19 respectively.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Version 0.0.2   (unreleased)
 • Additional optimization algorithms: Linearized ADMM and PDHG.
 • Move optimization algorithms into ``optimize`` subpackage.
 • Additional iteration stats columns for iterative ADMM subproblem solvers.
-• Renamed "Primal Residual" to "Prim Residual" in iteration stats.
+• Renamed "Primal Residual" to "Prml Residual" in iteration stats.
 • Bump pinned `jaxlib` and `jax` versions to 0.1.70 and 0.2.19 respectively.
 
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,14 +82,20 @@ Installing a Development Version
       pip install -e .  # Installs SCICO from the current directory in editable mode
 
 
-9. The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_
+9. The SCICO project uses the `black <https://black.readthedocs.io/en/stable/>`_
    and `isort <https://pypi.org/project/isort/>`_ code formatting utilities.
-   You should set up a `pre-commit hook <https://pre-commit.com>`_ to ensure
-   any modified code passes format check before it is committed to the development repo:
+   It is important to set up a `pre-commit hook <https://pre-commit.com>`_ to
+   ensure that any modified code passes format check before it is committed to
+   the development repo:
 
    ::
 
       pre-commit install  # Sets up git pre-commit hooks
+
+   It is also recommended to `pin the conda package version
+   <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#preventing-packages-from-updating-pinning>`__
+   of `black <https://black.readthedocs.io/en/stable/>`_ to the version
+   number specified in ``dev_requirements.txt``.
 
 
 10. For testing see `Tests`_.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,10 +82,10 @@ Installing a Development Version
       pip install -e .  # Installs SCICO from the current directory in editable mode
 
 
-9. The SCICO project uses the `Black <https://black.readthedocs.io/en/stable/>`_, `isort <https://pypi.org/project/isort/>`_ and `pylint <https://pylint.pycqa.org/en/latest/>`_ code formatting utilities.
-   It is important to set up a `pre-commit hook <https://pre-commit.com>`_ to
-   ensure that any modified code passes format check before it is committed to
-   the development repo:
+9. The SCICO project uses the `black <https://black.readthedocs.io/en/stable/>`_,
+   `isort <https://pypi.org/project/isort/>`_ and `pylint <https://pylint.pycqa.org/en/latest/>`_
+   code formatting utilities. It is important to set up a `pre-commit hook <https://pre-commit.com>`_ to
+   ensure that any modified code passes format check before it is committed to the development repo:
 
    ::
 

--- a/docs/source/team.rst
+++ b/docs/source/team.rst
@@ -41,3 +41,4 @@ Contributors
 - `Oleg Korobkin <https://github.com/korobkin>`_ (BlockArray improvements)
 - `Yanpeng Yuan <https://github.com/yanpeng7>`_ (ASTRA interface improvements)
 - `Soumendu Majee <https://github.com/smajee>`_ (SVMBIR interface improvements)
+- `Saurav Maheshkar <https://github.com/SauravMaheshkar>`_ (Improvements to pre-commit configuration)

--- a/examples/scripts/ct_astra_tv_admm.py
+++ b/examples/scripts/ct_astra_tv_admm.py
@@ -128,7 +128,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_astra_tv_admm.py
+++ b/examples/scripts/ct_astra_tv_admm.py
@@ -128,7 +128,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_svmbir_ppp_bm3d_admm_cg.py
+++ b/examples/scripts/ct_svmbir_ppp_bm3d_admm_cg.py
@@ -145,7 +145,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_svmbir_ppp_bm3d_admm_cg.py
+++ b/examples/scripts/ct_svmbir_ppp_bm3d_admm_cg.py
@@ -145,7 +145,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_svmbir_ppp_bm3d_admm_prox.py
+++ b/examples/scripts/ct_svmbir_ppp_bm3d_admm_prox.py
@@ -147,7 +147,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_svmbir_ppp_bm3d_admm_prox.py
+++ b/examples/scripts/ct_svmbir_ppp_bm3d_admm_prox.py
@@ -147,7 +147,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/ct_svmbir_tv_multi.py
+++ b/examples/scripts/ct_svmbir_tv_multi.py
@@ -205,7 +205,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Primal_Rsdl, hist_ladmm.Primal_Rsdl, hist_pdhg.Primal_Rsdl)).T,
+    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
     ptyp="semilogy",
     title="Primal residual",
     xlbl="Iteration",
@@ -236,7 +236,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Primal_Rsdl, hist_ladmm.Primal_Rsdl, hist_pdhg.Primal_Rsdl)).T,
+    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
     snp.vstack((hist_admm.Time, hist_ladmm.Time, hist_pdhg.Time)).T,
     ptyp="semilogy",
     title="Primal residual",

--- a/examples/scripts/ct_svmbir_tv_multi.py
+++ b/examples/scripts/ct_svmbir_tv_multi.py
@@ -205,7 +205,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
+    snp.vstack((hist_admm.Prml_Rsdl, hist_ladmm.Prml_Rsdl, hist_pdhg.Prml_Rsdl)).T,
     ptyp="semilogy",
     title="Primal residual",
     xlbl="Iteration",
@@ -236,7 +236,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
+    snp.vstack((hist_admm.Prml_Rsdl, hist_ladmm.Prml_Rsdl, hist_pdhg.Prml_Rsdl)).T,
     snp.vstack((hist_admm.Time, hist_ladmm.Time, hist_pdhg.Time)).T,
     ptyp="semilogy",
     title="Primal residual",

--- a/examples/scripts/deconv_circ_tv_admm.py
+++ b/examples/scripts/deconv_circ_tv_admm.py
@@ -110,7 +110,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_circ_tv_admm.py
+++ b/examples/scripts/deconv_circ_tv_admm.py
@@ -110,7 +110,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_microscopy_allchn_tv_admm.py
+++ b/examples/scripts/deconv_microscopy_allchn_tv_admm.py
@@ -272,7 +272,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    np.stack([s.Primal_Rsdl for s in solve_stats]).T,
+    np.stack([s.Prim_Rsdl for s in solve_stats]).T,
     ptyp="semilogy",
     title="Primal Residual",
     xlbl="Iteration",

--- a/examples/scripts/deconv_microscopy_allchn_tv_admm.py
+++ b/examples/scripts/deconv_microscopy_allchn_tv_admm.py
@@ -174,6 +174,7 @@ Define ray remote function for parallel solves.
 
 @ray.remote(num_cpus=ncpu, num_gpus=ngpu)
 def deconvolve_channel(channel):
+    """Deconvolve a single channel."""
     y_pad = jax.device_put(ray.get(y_pad_list)[channel])
     psf = jax.device_put(ray.get(psf_list)[channel])
     mask = jax.device_put(ray.get(mask_store))
@@ -272,7 +273,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    np.stack([s.Prim_Rsdl for s in solve_stats]).T,
+    np.stack([s.Prml_Rsdl for s in solve_stats]).T,
     ptyp="semilogy",
     title="Primal Residual",
     xlbl="Iteration",

--- a/examples/scripts/deconv_microscopy_tv_admm.py
+++ b/examples/scripts/deconv_microscopy_tv_admm.py
@@ -235,7 +235,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((solve_stats.Primal_Rsdl, solve_stats.Dual_Rsdl)).T,
+    snp.vstack((solve_stats.Prim_Rsdl, solve_stats.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_microscopy_tv_admm.py
+++ b/examples/scripts/deconv_microscopy_tv_admm.py
@@ -235,7 +235,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((solve_stats.Prim_Rsdl, solve_stats.Dual_Rsdl)).T,
+    snp.vstack((solve_stats.Prml_Rsdl, solve_stats.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_ppp_bm3d_admm.py
+++ b/examples/scripts/deconv_ppp_bm3d_admm.py
@@ -99,7 +99,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_ppp_bm3d_admm.py
+++ b/examples/scripts/deconv_ppp_bm3d_admm.py
@@ -99,7 +99,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_ppp_dncnn_admm.py
+++ b/examples/scripts/deconv_ppp_dncnn_admm.py
@@ -104,7 +104,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_ppp_dncnn_admm.py
+++ b/examples/scripts/deconv_ppp_dncnn_admm.py
@@ -104,7 +104,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_tv_admm.py
+++ b/examples/scripts/deconv_tv_admm.py
@@ -113,7 +113,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/deconv_tv_admm.py
+++ b/examples/scripts/deconv_tv_admm.py
@@ -113,7 +113,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/demosaic_ppp_bm3d_admm.py
+++ b/examples/scripts/demosaic_ppp_bm3d_admm.py
@@ -74,6 +74,7 @@ algorithm of :cite:`menon-2007-demosaicing` from package
 
 
 def demosaic(cfaimg):
+    """Apply baseline demosaicing."""
     return demosaicing_CFA_Bayer_Menon2007(cfaimg, pattern="BGGR").astype(np.float32)
 
 
@@ -141,7 +142,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prml_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/demosaic_ppp_bm3d_admm.py
+++ b/examples/scripts/demosaic_ppp_bm3d_admm.py
@@ -141,7 +141,7 @@ fig.show()
 Plot convergence statistics.
 """
 plot.plot(
-    snp.vstack((hist.Primal_Rsdl, hist.Dual_Rsdl)).T,
+    snp.vstack((hist.Prim_Rsdl, hist.Dual_Rsdl)).T,
     ptyp="semilogy",
     title="Residuals",
     xlbl="Iteration",

--- a/examples/scripts/denoise_tv_iso_multi.py
+++ b/examples/scripts/denoise_tv_iso_multi.py
@@ -147,7 +147,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
+    snp.vstack((hist_admm.Prml_Rsdl, hist_ladmm.Prml_Rsdl, hist_pdhg.Prml_Rsdl)).T,
     ptyp="semilogy",
     title="Primal residual",
     xlbl="Iteration",
@@ -178,7 +178,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
+    snp.vstack((hist_admm.Prml_Rsdl, hist_ladmm.Prml_Rsdl, hist_pdhg.Prml_Rsdl)).T,
     snp.vstack((hist_admm.Time, hist_ladmm.Time, hist_pdhg.Time)).T,
     ptyp="semilogy",
     title="Primal residual",

--- a/examples/scripts/denoise_tv_iso_multi.py
+++ b/examples/scripts/denoise_tv_iso_multi.py
@@ -147,7 +147,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Primal_Rsdl, hist_ladmm.Primal_Rsdl, hist_pdhg.Primal_Rsdl)).T,
+    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
     ptyp="semilogy",
     title="Primal residual",
     xlbl="Iteration",
@@ -178,7 +178,7 @@ plot.plot(
     ax=ax[0],
 )
 plot.plot(
-    snp.vstack((hist_admm.Primal_Rsdl, hist_ladmm.Primal_Rsdl, hist_pdhg.Primal_Rsdl)).T,
+    snp.vstack((hist_admm.Prim_Rsdl, hist_ladmm.Prim_Rsdl, hist_pdhg.Prim_Rsdl)).T,
     snp.vstack((hist_admm.Time, hist_ladmm.Time, hist_pdhg.Time)).T,
     ptyp="semilogy",
     title="Primal residual",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 testpaths = scico/test docs
 addopts = --doctest-glob="*rst"
 doctest_optionflags = NORMALIZE_WHITESPACE
+filterwarnings = ignore::DeprecationWarning:.*.compat

--- a/scico/__init__.py
+++ b/scico/__init__.py
@@ -15,7 +15,6 @@ import sys
 # isort: off
 from ._autograd import grad, jacrev, linear_adjoint, value_and_grad
 
-# TODO remove this check as we get closer to release?
 import jax, jaxlib
 
 jax_ver_req = "0.2.26"

--- a/scico/diagnostics.py
+++ b/scico/diagnostics.py
@@ -88,39 +88,34 @@ class IterationStats:
         # Names of fields in namedtuple used to record iteration values
         self.tuplefields = []
         # Compile regex for decomposing format strings
-        flre = re.compile(r"%(\+)?(\d+)(.*)")
+        fmre = re.compile(r"%(\+?-?)((?:\d+)?)(\.?)((?:\d+)?)([a-z])")
         # Iterate over field names
         for name in fields:
             # Get format string and decompose it using compiled regex
             fmt = fields[name]
-            rem = flre.match(fmt)
-            if rem is None:
-                # If format string does not contain a field length specifier,
-                # the field length is determined by the length of the header
-                # string
-                fln = max(len(name), len(fmt % 0))
-                fmt = "%%%d" % fln + fmt[1:]
-            else:
-                # If the format string does contain a field length specifier,
-                # the field length is the maximum of specified field length
-                # and the length of the header string
-                fmtlen = len(fmt % 0)
-                fln = int(rem.group(2))
-                if fmtlen > fln:
-                    warnings.warn(
-                        f'Actual length {fmtlen} of format "{fmt}" for field '
-                        f"{name} is longer than specified value {fln}",
-                        stacklevel=2,
-                    )
-                fln = max(len(name), fln)
-                sgn = rem.group(1)
-                if sgn is None:
-                    sgn = ""
-                fmt = "%" + sgn + ("%d" % fln) + rem.group(3)
+            fmtmatch = fmre.match(fmt)
+            if not fmtmatch:
+                raise ValueError(f'Format string "{fmt}" could not be parsed')
+            fmflg, fmlen, fmdot, fmprc, fmtyp = fmtmatch.groups()
+            flen = len(fmt % 0)
+            # Warn if actual formatted length longer than specified field
+            # length, e.g. as in "%4e"
+            if fmlen != "" and flen > int(fmlen):
+                warnings.warn(
+                    f'Actual length {flen} of format "{fmt}" for field '
+                    f'"{name}" is longer than specified value {fmlen}',
+                    stacklevel=2,
+                )
+            # If the actual formatted length is less than that of the header
+            # string, insert a field length specifier to increase the
+            # length to that of the header string
+            if flen < len(name):
+                fmt = f"%{fmflg}{len(name)}{fmdot}{fmprc}{fmtyp}"
+                flen = len(name)
             self.fieldname.append(name)
             self.fieldformat.append(fmt)
-            self.fieldlength.append(fln)
-            self.headlength += fln + colsep
+            self.fieldlength.append(flen)
+            self.headlength += flen + colsep
 
             # If a distinct identifier is specified for this field, use it
             # as the namedtuple identifier, otherwise compute it from the

--- a/scico/optimize/_ladmm.py
+++ b/scico/optimize/_ladmm.py
@@ -136,9 +136,9 @@ class LinearizedADMM:
             itstat_fields = {
                 "Iter": "%d",
                 "Time": "%8.2e",
-                "Objective": "%8.3e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
+                "Objective": "%9.3e",
+                "Primal Rsdl": "%9.3e",
+                "Dual Rsdl": "%9.3e",
             }
 
             def itstat_func(obj):
@@ -154,9 +154,9 @@ class LinearizedADMM:
             # The 'g' function can't be evaluated, so drop objective from the default itstat
             itstat_fields = {
                 "Iter": "%d",
-                "Time": "%8.1e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
+                "Time": "%8.2e",
+                "Primal Rsdl": "%9.3e",
+                "Dual Rsdl": "%9.3e",
             }
 
             def itstat_func(obj):

--- a/scico/optimize/_ladmm.py
+++ b/scico/optimize/_ladmm.py
@@ -142,7 +142,7 @@ class LinearizedADMM:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prml Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831

--- a/scico/optimize/_ladmm.py
+++ b/scico/optimize/_ladmm.py
@@ -142,7 +142,7 @@ class LinearizedADMM:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Primal Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831

--- a/scico/optimize/_ladmm.py
+++ b/scico/optimize/_ladmm.py
@@ -131,45 +131,29 @@ class LinearizedADMM:
         self.maxiter: int = maxiter
         self.timer: Timer = Timer()
 
+        # iteration number and time fields
+        itstat_fields = {
+            "Iter": "%d",
+            "Time": "%8.2e",
+        }
+        itstat_attrib = ["itnum", "timer.elapsed()"]
+        # objective function can be evaluated if all 'g' functions can be evaluated
         if g.has_eval:
-            # The 'g' functions can be evaluated, so objective function can be evaluated
-            itstat_fields = {
-                "Iter": "%d",
-                "Time": "%8.2e",
-                "Objective": "%9.3e",
-                "Primal Rsdl": "%9.3e",
-                "Dual Rsdl": "%9.3e",
-            }
+            itstat_fields.update({"Objective": "%9.3e"})
+            itstat_attrib.append("objective()")
+        # primal and dual residual fields
+        itstat_fields.update({"Primal Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
-            def itstat_func(obj):
-                return (
-                    obj.itnum,
-                    obj.timer.elapsed(),
-                    obj.objective(),
-                    obj.norm_primal_residual(),
-                    obj.norm_dual_residual(),
-                )
+        # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831
+        itstat_return = "return(" + ", ".join(["obj." + attr for attr in itstat_attrib]) + ")"
+        scope = {}
+        exec("def itstat_func(obj): " + itstat_return, scope)
 
-        else:
-            # The 'g' function can't be evaluated, so drop objective from the default itstat
-            itstat_fields = {
-                "Iter": "%d",
-                "Time": "%8.2e",
-                "Primal Rsdl": "%9.3e",
-                "Dual Rsdl": "%9.3e",
-            }
-
-            def itstat_func(obj):
-                return (
-                    obj.itnum,
-                    obj.timer.elapsed(),
-                    obj.norm_primal_residual(),
-                    obj.norm_dual_residual(),
-                )
-
+        # determine itstat options and initialize IterationStats object
         default_itstat_options = {
             "fields": itstat_fields,
-            "itstat_func": itstat_func,
+            "itstat_func": scope["itstat_func"],
             "display": False,
         }
         if itstat_options:

--- a/scico/optimize/_primaldual.py
+++ b/scico/optimize/_primaldual.py
@@ -140,9 +140,9 @@ class PDHG:
             itstat_fields = {
                 "Iter": "%d",
                 "Time": "%8.2e",
-                "Objective": "%8.3e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
+                "Objective": "%9.3e",
+                "Primal Rsdl": "%9.3e",
+                "Dual Rsdl": "%9.3e",
             }
 
             def itstat_func(obj):
@@ -158,9 +158,9 @@ class PDHG:
             # The 'g' function can't be evaluated, so drop objective from the default itstat
             itstat_fields = {
                 "Iter": "%d",
-                "Time": "%8.1e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
+                "Time": "%8.2e",
+                "Primal Rsdl": "%9.3e",
+                "Dual Rsdl": "%9.3e",
             }
 
             def itstat_func(obj):

--- a/scico/optimize/_primaldual.py
+++ b/scico/optimize/_primaldual.py
@@ -146,7 +146,7 @@ class PDHG:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prml Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831

--- a/scico/optimize/_primaldual.py
+++ b/scico/optimize/_primaldual.py
@@ -146,7 +146,7 @@ class PDHG:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Primal Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -452,45 +452,29 @@ class ADMM:
         self.subproblem_solver: SubproblemSolver = subproblem_solver
         self.subproblem_solver.internal_init(self)
 
+        # iteration number and time fields
+        itstat_fields = {
+            "Iter": "%d",
+            "Time": "%8.2e",
+        }
+        itstat_attrib = ["itnum", "timer.elapsed()"]
+        # objective function can be evaluated if all 'g' functions can be evaluated
         if all([_.has_eval for _ in self.g_list]):
-            # All 'g' functions can be evaluated, so objective function can be evaluated
-            itstat_fields = {
-                "Iter": "%d",
-                "Time": "%8.2e",
-                "Objective": "%8.3e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
-            }
+            itstat_fields.update({"Objective": "%8.3e"})
+            itstat_attrib.append("objective()")
+        # ADMM primal and dual residual fields
+        itstat_fields.update({"Primal Rsdl": "%8.3e", "Dual Rsdl": "%8.3e"})
+        itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
-            def itstat_func(obj):
-                return (
-                    obj.itnum,
-                    obj.timer.elapsed(),
-                    obj.objective(),
-                    obj.norm_primal_residual(),
-                    obj.norm_dual_residual(),
-                )
+        # dynamically create itstat_func; see https://stackoverflow.com/questions/24733831
+        itstat_return = "return(" + ", ".join(["obj." + attr for attr in itstat_attrib]) + ")"
+        scope = {}
+        exec("def itstat_func(obj): " + itstat_return, scope)
 
-        else:
-            # At least one 'g' can't be evaluated, so drop objective from the default itstat
-            itstat_fields = {
-                "Iter": "%d",
-                "Time": "%8.1e",
-                "Primal Rsdl": "%8.3e",
-                "Dual Rsdl": "%8.3e",
-            }
-
-            def itstat_func(obj):
-                return (
-                    obj.itnum,
-                    obj.timer.elapsed(),
-                    obj.norm_primal_residual(),
-                    obj.norm_dual_residual(),
-                )
-
+        # determine itstat options and initialize IterationStats object
         default_itstat_options = {
             "fields": itstat_fields,
-            "itstat_func": itstat_func,
+            "itstat_func": scope["itstat_func"],
             "display": False,
         }
         if itstat_options:

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -478,7 +478,7 @@ class ADMM:
                 ["subproblem_solver.info['nfev']", "subproblem_solver.info['nit']"]
             )
         elif (
-            isinstance(self.subproblem_solver, LinearSubproblemSolver)
+            type(self.subproblem_solver) == LinearSubproblemSolver
             and self.subproblem_solver.cg_function == "scico"
         ):
             itstat_fields.update({"CG It": "%5d", "CG Res": "%8.3e"})

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -465,10 +465,10 @@ class ADMM:
         itstat_attrib = ["itnum", "timer.elapsed()"]
         # objective function can be evaluated if all 'g' functions can be evaluated
         if all([_.has_eval for _ in self.g_list]):
-            itstat_fields.update({"Objective": "%8.3e"})
+            itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Primal Rsdl": "%8.3e", "Dual Rsdl": "%8.3e"})
+        itstat_fields.update({"Primal Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # subproblem solver info when available
@@ -481,7 +481,7 @@ class ADMM:
             type(self.subproblem_solver) == LinearSubproblemSolver
             and self.subproblem_solver.cg_function == "scico"
         ):
-            itstat_fields.update({"CG It": "%5d", "CG Res": "%8.3e"})
+            itstat_fields.update({"CG It": "%5d", "CG Res": "%9.3e"})
             itstat_attrib.extend(
                 ["subproblem_solver.info['num_iter']", "subproblem_solver.info['rel_res']"]
             )

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -462,7 +462,7 @@ class ADMM:
         if all([_.has_eval for _ in self.g_list]):
             itstat_fields.update({"Objective": "%8.3e"})
             itstat_attrib.append("objective()")
-        # ADMM primal and dual residual fields
+        # primal and dual residual fields
         itstat_fields.update({"Primal Rsdl": "%8.3e", "Dual Rsdl": "%8.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -468,7 +468,7 @@ class ADMM:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prml Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # subproblem solver info when available

--- a/scico/optimize/admm.py
+++ b/scico/optimize/admm.py
@@ -468,7 +468,7 @@ class ADMM:
             itstat_fields.update({"Objective": "%9.3e"})
             itstat_attrib.append("objective()")
         # primal and dual residual fields
-        itstat_fields.update({"Primal Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
+        itstat_fields.update({"Prim Rsdl": "%9.3e", "Dual Rsdl": "%9.3e"})
         itstat_attrib.extend(["norm_primal_residual()", "norm_dual_residual()"])
 
         # subproblem solver info when available

--- a/scico/optimize/pgm.py
+++ b/scico/optimize/pgm.py
@@ -458,9 +458,9 @@ class PGM:
             itstat_fields = {
                 "Iter": "%d",
                 "Time": "%8.2e",
-                "Objective": "%8.3e",
-                "L": "%8.3e",
-                "Residual": "%8.3e",
+                "Objective": "%9.3e",
+                "L": "%9.3e",
+                "Residual": "%9.3e",
             }
             itstat_func = lambda pgm: (
                 pgm.itnum,
@@ -470,7 +470,7 @@ class PGM:
                 pgm.norm_residual(),
             )
         else:
-            itstat_fields = {"Iter": "%d", "Time": "%8.2e", "Residual": "%8.3e"}
+            itstat_fields = {"Iter": "%d", "Time": "%8.2e", "Residual": "%9.3e"}
             itstat_func = lambda pgm: (pgm.itnum, pgm.timer.elapsed(), pgm.norm_residual())
 
         default_itstat_options = {

--- a/scico/test/optimize/test_admm.py
+++ b/scico/test/optimize/test_admm.py
@@ -39,7 +39,7 @@ class TestMisc:
             maxiter=maxiter,
             itstat_options={"display": False},
         )
-        assert len(admm_.itstat_object.fieldname) == 4
+        assert len(admm_.itstat_object.fieldname) == 6
         assert snp.sum(admm_.x) == 0.0
         admm_ = ADMM(
             f=f,

--- a/scico/test/test_diagnostics.py
+++ b/scico/test/test_diagnostics.py
@@ -1,17 +1,19 @@
 from collections import OrderedDict
 
+import pytest
+
 from scico import diagnostics
 
 
 class TestSet:
     def test_itstat(self):
-        its = diagnostics.IterationStats(OrderedDict({"Iter": "%d", "Objective": "%8.2e"}))
+        its = diagnostics.IterationStats(OrderedDict({"Iter": "%d", "Obj Val": "%8.2e"}))
         its.insert((0, 1.5))
         its.insert((1, 1e2))
         assert its.history()[0].Iter == 0
         assert its.history()[1].Iter == 1
-        assert its.history()[1].Objective == 1e2
-        assert its.history(transpose=True).Objective == [1.5, 100.0]
+        assert its.history()[1].Obj_Val == 1e2
+        assert its.history(transpose=True).Obj_Val == [1.5, 100.0]
 
     def test_display(self, capsys):
         its = diagnostics.IterationStats({"Iter": "%d"}, display=True, period=2, overwrite=False)
@@ -24,3 +26,13 @@ class TestSet:
         its.insert((2,))
         cap = capsys.readouterr()
         assert cap.out == "   2\n"
+
+    def test_exception(self):
+        with pytest.raises(TypeError):
+            its = diagnostics.IterationStats(["Iter", "%z4d"], display=False)
+        with pytest.raises(ValueError):
+            its = diagnostics.IterationStats({"Iter": "%z4d"}, display=False)
+
+    def test_warning(self):
+        with pytest.warns(UserWarning):
+            its = diagnostics.IterationStats({"Iter": "%4e"}, display=False)

--- a/setup.py
+++ b/setup.py
@@ -13,27 +13,48 @@ name = "scico"
 
 # Get version number from scico/__init__.py
 # See http://stackoverflow.com/questions/2058802
-with open(os.path.join(name, "__init__.py")) as f:
-    version = parse(next(filter(lambda line: line.startswith("__version__"), f))).body[0].value.s
+def get_init_variable_value(var):
+    with open(os.path.join(name, "__init__.py")) as f:
+        try:
+            value = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value.s
+        except StopIteration:
+            raise RuntimeError(f"Could not find initialization of variable {var}")
+    return value
+
+
+version = get_init_variable_value("__version_")
 
 packages = find_packages()
-
 
 longdesc = """
 SCICO is a Python package for solving the inverse problems that arise in scientific imaging applications. Its primary focus is providing methods for solving ill-posed inverse problems by using an appropriate prior model of the reconstruction space. SCICO includes a growing suite of operators, cost functionals, regularizers, and optimization routines that may be combined to solve a wide range of problems, and is designed so that it is easy to add new building blocks. SCICO is built on top of JAX, which provides features such as automatic gradient calculation and GPU acceleration.
 """
 
-install_requires = [
-    "numpy>=1.12",
-    "scipy>=0.19.1",
-    "imageio",
-    "matplotlib",
-    "jaxlib>=0.1.70",
-    "jax>=0.2.19",
-    "flax",
-    "bm3d",
-    "svmbir",
-]
+# Set install_requires from requirements.txt file
+with open(os.path.join("requirements.txt")) as f:
+    lines = f.readlines()
+install_requires = [line.strip() for line in lines]
+
+# Check that jaxlib version requirements in __init__.py and requirements.txt match
+jaxlib_ver = get_init_variable_value("jaxlib_ver_req")
+req_jaxlib_ver = list(filter(lambda s: s.startswith("jaxlib"), install_requires))[0].split("==")[1]
+if jaxlib_ver != req_jaxlib_ver:
+    raise ValueError(
+        f"Version requirements for jaxlib in __init__.py ({jaxlib_ver}) and "
+        f"requirements.txt ({req_jaxlib_ver}) do not match"
+    )
+
+# Check that jax version requirements in __init__.py and requirements.txt match
+jax_ver = get_init_variable_value("jax_ver_req")
+req_jax_ver = list(
+    filter(lambda s: s.startswith("jax") and not s.startswith("jaxlib"), install_requires)
+)[0].split("==")[1]
+if jax_ver != req_jax_ver:
+    raise ValueError(
+        f"Version requirements for jax in __init__.py ({jax_ver}) and "
+        f"requirements.txt ({req_jax_ver}) do not match"
+    )
+
 tests_require = ["pytest", "pytest-runner"]
 python_requires = ">=3.8"
 


### PR DESCRIPTION
- Modify `setup.py` to improve consistency in dependency specification
- Add note to docs on pinning black version in conda
- Implement more compact iteration stats initialization in optimizer classes (except PGM)
- Additional iteration stats columns for iterative ADMM subproblem solvers
- More robust implementation of `IterationStats.__init__`
- Abbreviate ADMM primal residual column name in iteration stats
- Suppress annoying pytest DeprecationWarning regarding imp in compat
