### PR TITLE
Allow Diagonal to use broadcasting

### DIFF
--- a/scico/linop/_linop.py
+++ b/scico/linop/_linop.py
@@ -167,22 +167,44 @@ def valid_adjoint(
 class Diagonal(LinearOperator):
     """Diagonal linear operator."""
 
-    def __init__(self, diagonal: JaxArray, input_dtype: Optional[DType] = None, **kwargs):
+    def __init__(
+        self,
+        diagonal: Union[Array, BlockArray],
+        input_shape: Optional[Shape] = None,
+        input_dtype: Optional[DType] = None,
+        **kwargs,
+    ):
         r"""
         Args:
             diagonal:  Diagonal elements of this linear operator
+            input_shape:  Shape of input array. By default, equal to `diagonal.shape`,
+               but may also be set to a shape that is broadcast-compatiable with `diagonal.shape`.
             input_dtype:  `dtype` of input argument.  The default, ``None``,
                means `diagonal.dtype`.
+
         """
 
         self.diagonal = util.ensure_on_device(diagonal)
 
+        if input_shape is None:
+            input_shape = self.diagonal.shape
+
         if input_dtype is None:
             input_dtype = self.diagonal.dtype
+
+        if isinstance(diagonal, BlockArray) and util.is_nested(input_shape):
+            output_shape = (snp.empty(input_shape) * diagonal).shape
+        elif not isinstance(diagonal, BlockArray) and not util.is_nested(input_shape):
+            output_shape = snp.broadcast_shapes(input_shape, self.diagonal.shape)
+        elif isinstance(diagonal, BlockArray):
+            raise ValueError(f"`diagonal` was a BlockArray but `input_shape` was not nested.")
+        else:
+            raise ValueError(f"`diagonal` was a not BlockArray but `input_shape` was nested.")
+
         super().__init__(
-            input_shape=self.diagonal.shape,
+            input_shape=input_shape,
             input_dtype=input_dtype,
-            output_shape=self.diagonal.shape,
+            output_shape=output_shape,
             output_dtype=input_dtype,
             **kwargs,
         )


### PR DESCRIPTION
The part I'm least happy with is that I find the resulting (broadcasted) shape of `x * y` for two BlockArrays empirically, i.e., by multiplying zeros together. I would love an `snp.broadcast_shapes` but adding it was nontrivial.