### PR TITLE
Address readthedocs build failure

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -2,7 +2,7 @@
 sphinx>=3.5.2
 sphinxcontrib-napoleon
 sphinxcontrib-bibtex
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints==1.14.1
 faculty-sphinx-theme
 nbsphinx
 py2jn


### PR DESCRIPTION
As a temporary solution, pin `sphinx-autodoc-typehints` to v1.14.1. See #168.