### PR TITLE
Bump sphinx-autodoc-typehints version to avoid readthedocs build error

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -2,7 +2,7 @@
 sphinx>=3.5.2
 sphinxcontrib-napoleon
 sphinxcontrib-bibtex
-sphinx-autodoc-typehints==1.14.1
+sphinx-autodoc-typehints>=1.15.2
 faculty-sphinx-theme
 nbsphinx
 py2jn


### PR DESCRIPTION
Closes #168 