### PR TITLE
Silence docs build warnings

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -2,7 +2,7 @@
 sphinx>=3.5.2
 sphinxcontrib-napoleon
 sphinxcontrib-bibtex
-sphinx-autodoc-typehints>=1.15.2
+sphinx-autodoc-typehints
 faculty-sphinx-theme
 nbsphinx
 py2jn

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -438,6 +438,19 @@ def class_inherit_diagrams(_):
         insert_inheritance_diagram(cls)
 
 
+def process_docstring(app, what, name, obj, options, lines):
+    # Don't show docs for inherited members in classes in scico.flax.
+    # This is primarily useful for silencing warnings due to problems in
+    # the current release of flax, but is arguably also useful in avoiding
+    # extensive documentation of methods that are likely to be of limited
+    # interest to users of the scico.flax classes.
+    #
+    # See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+    # for documentation of the autodoc-process-docstring event used here.
+    if what == "class" and "scico.flax." in name:
+        options["inherited-members"] = False
+
+
 def setup(app):
 
     app.add_css_file("scico.css")
@@ -445,3 +458,4 @@ def setup(app):
         "http://netdna.bootstrapcdn.com/font-awesome/4.7.0/" "css/font-awesome.min.css"
     )
     app.connect("builder-inited", class_inherit_diagrams)
+    app.connect("autodoc-process-docstring", process_docstring)

--- a/scico/flax.py
+++ b/scico/flax.py
@@ -14,7 +14,14 @@ import jax.numpy as jnp
 
 from flax import linen as nn
 from flax import serialization
+from flax.core import Scope  # noqa
+from flax.linen.module import _Sentinel  # noqa
 
+# The imports of Scope and _Sentinel (above) and the definition of Module
+# (below) are required to silence "cannot resolve forward reference"
+# warnings when building sphinx api docs.
+
+Module = nn.module.Module
 ModuleDef = Any
 Array = Any
 


### PR DESCRIPTION
Silence docs build warnings discussed in #167. As a side effect (the desirability of which is perhaps worthy of discussion), disables documentation of inherited methods in `scico.jax` classes. In addition, the version pinning of `sphinx-autodoc-typehints` introduced in #171 is no longer necessary (also worth discussing whether this pinning should now be removed).

