### PR TITLE
Fix some problems in DnCNN implementation and example

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, Los Alamos National Laboratory
+Copyright (c) 2021-2022, Los Alamos National Laboratory
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,7 +155,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "SCICO"
-copyright = "2020-2021, SCICO Developers"
+copyright = "2020-2022, SCICO Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/examples/scripts/deconv_ppp_dncnn_admm.py
+++ b/examples/scripts/deconv_ppp_dncnn_admm.py
@@ -59,7 +59,7 @@ g = functional.DnCNN("17M")
 """
 Set up an ADMM solver.
 """
-ρ = 1.0  # ADMM penalty parameter
+ρ = 0.2  # ADMM penalty parameter
 maxiter = 10  # number of ADMM iterations
 
 f = loss.SquaredL2Loss(y=y, A=A)

--- a/examples/scripts/deconv_ppp_dncnn_admm.py
+++ b/examples/scripts/deconv_ppp_dncnn_admm.py
@@ -53,8 +53,7 @@ y = Ax + σ * noise
 """
 Load DnCNN denoiser and create map object.
 """
-λ = 15.0 / 255  # regularization strength
-g = λ * functional.DnCNN("17M")
+g = functional.DnCNN("17M")
 
 
 """

--- a/scico/functional/_denoiser.py
+++ b/scico/functional/_denoiser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2021 by SCICO Developers
+# Copyright (C) 2020-2022 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -40,12 +40,12 @@ class BM3D(Functional):
     has_prox = True
     is_smooth = False
 
-    def __init__(self, is_rgb: Optional[bool] = False):
+    def __init__(self, is_rgb: bool = False):
         r"""Initialize a :class:`BM3D` object.
 
         Args:
             is_rgb: Flag indicating use of BM3D with a color transform.
-                    Default: False.
+                    Default: ``False``.
         """
 
         if is_rgb is True:
@@ -58,11 +58,11 @@ class BM3D(Functional):
         super().__init__()
 
     def prox(self, x: JaxArray, lam: float = 1.0, **kwargs) -> JaxArray:
-        r"""Apply BM3D denoiser with noise level ``lam``.
+        r"""Apply BM3D denoiser.
 
         Args:
             x: input image.
-            lam: noise level.
+            lam: noise parameter.
 
         Returns:
             BM3D denoised output.
@@ -88,12 +88,12 @@ class BM3D(Functional):
 
         # this check is also performed inside the BM3D call, but due to the host_callback,
         # no exception is raised and the program will crash with no traceback.
-        # NOTE:  if BM3D is extended to allow for different profiles, the block size must be
-        #        updated; this presumes 'np' profile (bs=8)
+        # NOTE: if BM3D is extended to allow for different profiles, the block size must be
+        #       updated; this presumes 'np' profile (bs=8)
         if np.min(x.shape[:2]) < 8:
             raise ValueError(
                 f"Two leading dimensions of input cannot be smaller than block size "
-                f"(8);  got image size = {x.shape}"
+                f"(8); got image size = {x.shape}"
             )
 
         if x.ndim > 3:
@@ -148,15 +148,15 @@ class DnCNN(FlaxMap):
         variables = load_weights(_flax_data_path("dncnn%s.npz" % variant))
         super().__init__(model, variables)
 
-    def prox(self, x: JaxArray, lam: float = 1) -> JaxArray:
+    def prox(self, x: JaxArray, lam: float = 1, **kwargs) -> JaxArray:
         r"""Apply DnCNN denoiser.
 
-        *Warning*: The ``lam`` parameter is ignored, and has no effect on
+        *Warning*: The `lam` parameter is ignored, and has no effect on
         the output.
 
         Args:
             x: input.
-            lam: noise estimate (ignored).
+            lam: noise parameter (ignored).
 
         Returns:
             DnCNN denoised output.


### PR DESCRIPTION
Primary fixes:
* Redundant scaling parameter for DnCNN prox in the example.
* Missing ``**kwargs`` in signature resulted in failure when prox called without a scaling.

Also a number of other minor changes.