### PR TITLE
Make output types jax-array

### DIFF
--- a/scico/functional/_denoiser.py
+++ b/scico/functional/_denoiser.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import numpy as np
 
-import jax
 from jax.experimental import host_callback as hcb
 
 from bm3d import bm3d, bm3d_rgb
@@ -111,7 +110,7 @@ class BM3D(Functional):
         # undo squeezing, if neccessary
         y = y.reshape(x_in_shape)
 
-        return jax.device_put(y)
+        return y
 
 
 class DnCNN(FlaxMap):

--- a/scico/functional/_denoiser.py
+++ b/scico/functional/_denoiser.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import numpy as np
 
+import jax
 from jax.experimental import host_callback as hcb
 
 from bm3d import bm3d, bm3d_rgb
@@ -110,7 +111,7 @@ class BM3D(Functional):
         # undo squeezing, if neccessary
         y = y.reshape(x_in_shape)
 
-        return y
+        return jax.device_put(y)
 
 
 class DnCNN(FlaxMap):

--- a/scico/linop/radon_svmbir.py
+++ b/scico/linop/radon_svmbir.py
@@ -109,13 +109,15 @@ class ParallelBeamProjector(LinearOperator):
         center_offset: Optional[float] = 0.0,
         roi_radius: Optional[float] = None,
     ) -> JaxArray:
-        return svmbir.project(
-            np.array(x),
-            np.array(angles),
-            num_channels,
-            verbose=0,
-            center_offset=center_offset,
-            roi_radius=roi_radius,
+        return jax.device_put(
+            svmbir.project(
+                np.array(x),
+                np.array(angles),
+                num_channels,
+                verbose=0,
+                center_offset=center_offset,
+                roi_radius=roi_radius,
+            )
         )
 
     def _proj_hcb(self, x):
@@ -143,14 +145,16 @@ class ParallelBeamProjector(LinearOperator):
         center_offset: Optional[float] = 0.0,
         roi_radius: Optional[float] = None,
     ):
-        return svmbir.backproject(
-            np.array(y),
-            np.array(angles),
-            num_rows,
-            num_cols,
-            verbose=0,
-            center_offset=center_offset,
-            roi_radius=roi_radius,
+        return jax.device_put(
+            svmbir.backproject(
+                np.array(y),
+                np.array(angles),
+                num_rows,
+                num_cols,
+                verbose=0,
+                center_offset=center_offset,
+                roi_radius=roi_radius,
+            )
         )
 
     def _bproj_hcb(self, y):


### PR DESCRIPTION
Fixes output types of svmbir and bm3d to be always jaxarrays. Fixes issue #93 