### PR TITLE
Address excessive memory usage in `functional.NuclearNorm.__call__`

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -140,8 +140,8 @@
 @InProceedings{dabov-2008-image,
   author =	 {Kostadin Dabov and Alessandro Foi and Vladimir
                   Katkovnik and Karen Egiazarian},
-  title =	 {{Image restoration by sparse 3D transform-domain
-                  collaborative filtering}},
+  title =	 {Image restoration by sparse {3D} transform-domain
+                  collaborative filtering},
   volume =	 6812,
   booktitle =	 {Image Processing: Algorithms and Systems VI},
   editor =	 {Jaakko T. Astola and Karen O. Egiazarian and Edward
@@ -324,7 +324,7 @@
                   algorithms in convex optimization},
   booktitle =	 {Proceedings of the International Conference on
                   Computer Vision (ICCV)},
-  doi =	 {10.1109/iccv.2011.6126441},
+  doi =	         {10.1109/iccv.2011.6126441},
   pages =	 {1762--1769},
   year =	 2011,
   month =	 Nov,
@@ -371,7 +371,7 @@
 
 @Misc {pyabel-2022,
   author =	 {Stephen Gibson and Daniel Hickstein and Roman Yurchak,
-              Mikhail Ryazanov and Dhrubajyoti Das and Gilbert Shih},
+                  Mikhail Ryazanov and Dhrubajyoti Das and Gilbert Shih},
   title =	 {PyAbel},
   howpublished = {PyAbel/PyAbel: v0.8.5},
   year =	 2022,

--- a/scico/functional/_norm.py
+++ b/scico/functional/_norm.py
@@ -273,9 +273,13 @@ class NuclearNorm(Functional):
     has_prox = True
 
     def __call__(self, x: Union[JaxArray, BlockArray]) -> float:
-        # Set computute_uv=True to work around
-        # https://github.com/google/jax/issues/9483
-        _, s, _ = snp.linalg.svd(x, compute_uv=True)
+        # Original implementation of this function was
+        #   return snp.sum(snp.linalg.svd(x, compute_uv=False))
+        # The implementation here is a temporary work-around due
+        # to the bug reported at https://github.com/google/jax/issues/9483
+        s = snp.linalg.svd(x, full_matrices=False, compute_uv=False)
+        if isinstance(s, tuple):
+            _, s, _ = snp.linalg.svd(x, full_matrices=False, compute_uv=True)
         return snp.sum(s)
 
     def prox(

--- a/scico/functional/_norm.py
+++ b/scico/functional/_norm.py
@@ -279,7 +279,7 @@ class NuclearNorm(Functional):
         # to the bug reported at https://github.com/google/jax/issues/9483
         s = snp.linalg.svd(x, full_matrices=False, compute_uv=False)
         if isinstance(s, tuple):
-            _, s, _ = snp.linalg.svd(x, full_matrices=False, compute_uv=True)
+            s = s[1]
         return snp.sum(s)
 
     def prox(


### PR DESCRIPTION
A minor change to the work-around for google/jax#9483 that takes advantage of the low frequency of occurrence of the bug, and avoids potentially very high memory requirements for non-square matrices by use of the `full_matrices=False`  option.