### PR TITLE
add check for A not linop in prox

### DIFF
--- a/scico/loss.py
+++ b/scico/loss.py
@@ -154,7 +154,7 @@ class WeightedSquaredL2Loss(Loss):
             prox_kwargs = dict
         self.prox_kwargs = prox_kwargs
 
-        if isinstance(self.A, linop.Diagonal) and isinstance(self.W, linop.Diagonal):
+        if isinstance(self.A, linop.LinearOperator):
             self.has_prox = True
 
     def __call__(self, x: Union[JaxArray, BlockArray]) -> float:
@@ -163,6 +163,12 @@ class WeightedSquaredL2Loss(Loss):
     def prox(
         self, v: Union[JaxArray, BlockArray], lam: float, **kwargs
     ) -> Union[JaxArray, BlockArray]:
+        if not isinstance(self.A, linop.LinearOperator):
+            raise NotImplementedError(
+                f"prox is not implemented for {type(self)} when `A` is {type(A)}; "
+                "must be LinearOperator"
+            )
+
         if isinstance(self.A, linop.Diagonal):
             c = 2.0 * self.scale * lam
             A = self.A.diagonal

--- a/scico/test/test_functional.py
+++ b/scico/test/test_functional.py
@@ -344,7 +344,7 @@ class TestLoss:
     def test_squared_l2(self):
         L = loss.SquaredL2Loss(y=self.y, A=self.Ao)
         assert L.has_eval == True
-        assert L.has_prox == False  # not diagonal
+        assert L.has_prox == True
 
         # test eval
         np.testing.assert_allclose(L(self.v), 0.5 * ((self.Ao @ self.v - self.y) ** 2).sum())
@@ -375,7 +375,7 @@ class TestLoss:
     def test_weighted_squared_l2(self):
         L = loss.WeightedSquaredL2Loss(y=self.y, A=self.Ao, W=self.W)
         assert L.has_eval == True
-        assert L.has_prox == False  # not diagonal
+        assert L.has_prox == True
 
         # test eval
         np.testing.assert_allclose(


### PR DESCRIPTION
See #215

Note that check for `self.has_prox`, namely that `W` is `Diagonal`, was redundant and so I removed it.