### PR TITLE
Make bm3d dependency optional

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,14 @@
 include MANIFEST.in
 include setup.py
-include setup.cfg
 include README.rst
 include LICENSE
 include CHANGES.rst
 include requirements.txt
+include dev_requirements.txt
+include examples/scriptcheck.sh
+include docs/docs_requirements.txt
 
 recursive-include scico *.py
 recursive-include scico/data *.png *.npz
 recursive-include docs Makefile *.py *.ipynb *.rst *.bib *.css *.svg *.ico
-recursive-include examples Makefile *.txt *.rst *.py
-include examples/pytojnb examples/scriptcheck
+recursive-include examples *_requirements.txt *.txt *.rst *.py

--- a/scico/denoiser.py
+++ b/scico/denoiser.py
@@ -12,7 +12,12 @@ import numpy as np
 
 from jax.experimental import host_callback as hcb
 
-import bm3d as tunibm3d
+try:
+    import bm3d as tunibm3d
+except ImportError:
+    have_bm3d = False
+else:
+    have_bm3d = True
 
 import scico.numpy as snp
 from scico._flax import DnCNNNet, load_weights
@@ -38,6 +43,8 @@ def bm3d(x: JaxArray, sigma: float, is_rgb: bool = False):
     Returns:
         Denoised output.
     """
+    if not have_bm3d:
+        raise RuntimeError("Package bm3d is required for use of this function." "")
 
     if is_rgb is True:
         bm3d_eval = tunibm3d.bm3d_rgb
@@ -45,7 +52,7 @@ def bm3d(x: JaxArray, sigma: float, is_rgb: bool = False):
         bm3d_eval = tunibm3d.bm3d
 
     if np.iscomplexobj(x):
-        raise TypeError(f"BM3D requries real-valued inputs, got {x.dtype}")
+        raise TypeError(f"BM3D requires real-valued inputs, got {x.dtype}")
 
     # Support arrays with more than three axes when the additional axes are singletons.
     x_in_shape = x.shape
@@ -94,7 +101,6 @@ class DnCNN(FlaxMap):
 
     def __init__(self, variant: str = "6M"):
         """
-
         Note that all DnCNN models are trained for single-channel image
         input. Multi-channel input is supported via independent denoising
         of each channel.

--- a/scico/linop/abel.py
+++ b/scico/linop/abel.py
@@ -65,10 +65,10 @@ class AbelProjector(LinearOperator):
         """Perform inverse Abel transform.
 
         Args:
-            y: Input image (assumed to be a result of an Abel transform)
+            y: Input image (assumed to be a result of an Abel transform).
 
         Returns:
-            Output of inverse Abel transform
+            Output of inverse Abel transform.
         """
         return _pyabel_transform(y, direction="inverse", proj_mat_quad=self.proj_mat_quad).astype(
             self.input_dtype

--- a/scico/ray/tune.py
+++ b/scico/ray/tune.py
@@ -24,8 +24,6 @@ from ray.tune.schedulers import AsyncHyperBandScheduler
 from ray.tune.suggest.hyperopt import HyperOptSearch
 from ray.tune.trial import Trial
 
-__author__ = """Brendt Wohlberg <brendt@ieee.org>"""
-
 
 class _CustomReporter(TuneReporterBase):
     """Custom status reporter for :mod:`ray.tune`."""

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     python_requires=python_requires,
     tests_require=tests_require,
     install_requires=install_requires,
-    extras_require={"tests": tests_require},
+    extras_require=extras_require,
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,10 @@ setup(
     long_description=longdesc,
     keywords=[
         "Computational Imaging",
+        "Scientific Imaging",
         "Inverse Problems",
+        "Plug-and-Play Priors",
+        "Total Variation",
         "Optimization",
         "ADMM",
         "Linearized ADMM",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ SCICO is a Python package for solving the inverse problems that arise in scienti
 """
 
 # Set install_requires from requirements.txt file
-with open(os.path.join("requirements.txt")) as f:
+with open("requirements.txt") as f:
     lines = f.readlines()
 install_requires = [line.strip() for line in lines]
 
@@ -59,8 +59,21 @@ if jax_ver != req_jax_ver:
         f"requirements.txt ({req_jax_ver}) do not match"
     )
 
-tests_require = ["pytest", "pytest-runner"]
 python_requires = ">=3.8"
+tests_require = ["pytest", "pytest-runner"]
+
+extra_require_files = [
+    "dev_requirements.txt",
+    os.path.join("docs", "docs_requirements.txt"),
+    os.path.join("examples", "examples_requirements.txt"),
+    os.path.join("examples", "notebooks_requirements.txt"),
+]
+extras_require = {"tests": tests_require}
+for require_file in extra_require_files:
+    extras_label = os.path.basename(require_file).partition("_")[0]
+    with open(require_file) as f:
+        lines = f.readlines()
+    extras_require[extras_label] = [line.strip() for line in lines if line[0:2] != "-r"]
 
 
 setup(
@@ -69,7 +82,15 @@ setup(
     description="Scientific Computational Imaging COde: A Python "
     "package for scientific imaging problems",
     long_description=longdesc,
-    keywords=["Computational Imaging", "Inverse Problems", "Optimization", "ADMM", "PGM"],
+    keywords=[
+        "Computational Imaging",
+        "Inverse Problems",
+        "Optimization",
+        "ADMM",
+        "Linearized ADMM",
+        "PDHG",
+        "PGM",
+    ],
     platforms="Any",
     license="BSD",
     url="https://github.com/lanl/scico",


### PR DESCRIPTION
* Make bm3d dependency optional in the sense that only functions and scripts that make direct use thereof cannot be used when it isn't installed
* Some minor packaging improvements