### PR TITLE
Fix readthedocs build failure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+  apt_packages:
+    - graphviz
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   builder: html
+   configuration: docs/source/conf.py
+   fail_on_warning: false
+
+# Declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/docs_requirements.txt

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -5,6 +5,7 @@ sphinxcontrib-bibtex
 sphinx-autodoc-typehints
 faculty-sphinx-theme
 nbsphinx
+ipython_genutils
 py2jn
 pygraphviz>=1.7
 pandoc

--- a/scico/_autograd.py
+++ b/scico/_autograd.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 by SCICO Developers
+# Copyright (C) 2020-2022 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -16,7 +16,7 @@ import jax.numpy as jnp
 def _append_jax_docs(fn, jaxfn=None):
     """Append the jax function docs.
 
-    Given wrapper function ``fn``, concatenate its docstring with the
+    Given wrapper function `fn`, concatenate its docstring with the
     docstring of the wrapped jax function.
     """
 
@@ -35,7 +35,7 @@ def grad(
     holomorphic: bool = False,
     allow_int: bool = False,
 ) -> Callable:
-    """Create a function that evaluates the gradient of ``fun``.
+    """Create a function that evaluates the gradient of `fun`.
 
     :func:`scico.grad` differs from :func:`jax.grad` in that the output
     is conjugated.
@@ -67,7 +67,7 @@ def value_and_grad(
     holomorphic: bool = False,
     allow_int: bool = False,
 ) -> Callable[..., Tuple[Any, Any]]:
-    """Create a function that evaluates both ``fun`` and its gradient.
+    """Create a function that evaluates both `fun` and its gradient.
 
     :func:`scico.value_and_grad` differs from :func:`jax.value_and_grad`
     in that the gradient is conjugated.
@@ -131,7 +131,7 @@ def jacrev(
     holomorphic: bool = False,
     allow_int: bool = False,
 ) -> Callable:
-    """Jacobian of ``fun`` evaluated row-by-row using reverse-mode AD.
+    """Jacobian of `fun` evaluated row-by-row using reverse-mode AD.
 
     :func:`scico.jacrev` differs from :func:`jax.jacrev` in that the
     output is conjugated.

--- a/scico/ray/__init__.py
+++ b/scico/ray/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2021 by SCICO Developers
+# Copyright (C) 2022 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""Simplified interfaces to :doc:`ray <ray:package-ref>`."""
+"""Simplified interfaces to :doc:`ray <ray-core/package-ref>`."""
 
 
 try:


### PR DESCRIPTION
Fix readthedocs build failure, and address some other minor docs issues.

Note: the fix involved adding `ipython_genutils` as a direct dependency in ` docs_requirements.txt`, presumably required due to an error in a recent release of one of the other docs dependencies. It should be removed when this error has been corrected.