### PR TITLE
Make SCICO compatible with jax 0.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy>=1.12
 scipy>=0.19.1
 imageio
 matplotlib
-jaxlib==0.3.0
-jax==0.3.0
+jaxlib>=0.3.0,<=0.3.2
+jax>=0.3.0,<=0.3.4
 flax>=0.4.0
 bm3d
 svmbir>=0.2.7

--- a/scico/blockarray.py
+++ b/scico/blockarray.py
@@ -1215,7 +1215,7 @@ class BlockArray:
         Returns:
             :class:`jax.ops.index` pointing to desired block.
         """
-        return jax.ops.index[self.bndpos[idx] : self.bndpos[idx + 1]]
+        return slice(self.bndpos[idx], self.bndpos[idx + 1])
 
     def ravel(self) -> JaxArray:
         """Return a copy of ``self._data`` as a contiguous, flattened `DeviceArray`.

--- a/scico/test/test_blockarray.py
+++ b/scico/test/test_blockarray.py
@@ -135,7 +135,7 @@ def test_devicearray_right(test_operator_obj, operator):
 
     x = operator(block_da, a).ravel()
     y = ba.BlockArray.array([operator(block_da[i], a[i]) for i in range(a.num_blocks)]).ravel()
-    np.testing.assert_allclose(x, y)
+    np.testing.assert_allclose(x, y, atol=1e-7, rtol=0)
 
 
 # Operations between two blockarrays of same size

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 
 import os
 import os.path
+import re
 import site
 from ast import parse
 
@@ -42,7 +43,11 @@ install_requires = [line.strip() for line in lines]
 
 # Check that jaxlib version requirements in __init__.py and requirements.txt match
 jaxlib_ver = get_init_variable_value("jaxlib_ver_req")
-req_jaxlib_ver = list(filter(lambda s: s.startswith("jaxlib"), install_requires))[0].split("==")[1]
+jaxlib_req_str = list(filter(lambda s: s.startswith("jaxlib"), install_requires))[0]
+m = re.match("jaxlib[=<>]+([\d\.]+)", jaxlib_req_str)
+if not m:
+    raise ValueError(f"Could not extract jaxlib version number from specification {jaxlib_req_str}")
+req_jaxlib_ver = m[1]
 if jaxlib_ver != req_jaxlib_ver:
     raise ValueError(
         f"Version requirements for jaxlib in __init__.py ({jaxlib_ver}) and "
@@ -51,9 +56,13 @@ if jaxlib_ver != req_jaxlib_ver:
 
 # Check that jax version requirements in __init__.py and requirements.txt match
 jax_ver = get_init_variable_value("jax_ver_req")
-req_jax_ver = list(
+jax_req_str = list(
     filter(lambda s: s.startswith("jax") and not s.startswith("jaxlib"), install_requires)
-)[0].split("==")[1]
+)[0]
+m = re.match("jax[=<>]+([\d\.]+)", jax_req_str)
+if not m:
+    raise ValueError(f"Could not extract jax version number from specification {jax_req_str}")
+req_jax_ver = m[1]
 if jax_ver != req_jax_ver:
     raise ValueError(
         f"Version requirements for jax in __init__.py ({jax_ver}) and "


### PR DESCRIPTION
Test failures were coming use of the deprecated `jax.ops.index`, appears to be functionally equivalent to `slice`. So, easy to fix.

Also needed to bump the tolerance on one blockarray test.