### PR TITLE
Sphinx autodoc configuration changes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -374,9 +374,10 @@ print("confpath: %s" % confpath)
 # Sort members by type
 autodoc_default_options = {
     "member-order": "bysource",
-    "inherited-members": True,
+    "inherited-members": False,
     "ignore-module-all": False,
     "show-inheritance": True,
+    "members": True,
     "special-members": "__call__",
 }
 autodoc_docstring_signature = True
@@ -488,6 +489,11 @@ def process_docstring(app, what, name, obj, options, lines):
     # the current release of flax, but is arguably also useful in avoiding
     # extensive documentation of methods that are likely to be of limited
     # interest to users of the scico.flax classes.
+    #
+    # Note: this event handler currently has no effect since inclusion of
+    #   inherited members is currently globally disabled (see
+    #   "inherited-members" in autodoc_default_options), but is left in
+    #   place in case a decision is ever made to revert the global setting.
     #
     # See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
     # for documentation of the autodoc-process-docstring event used here.

--- a/scico/linop/_linop.py
+++ b/scico/linop/_linop.py
@@ -315,8 +315,8 @@ def linop_from_function(f: Callable, classname: str, f_name: Optional[str] = Non
         f: Function from which to create a linear operator class
         classname: Name of the resulting class.
         f_name: Name of `f` for use in docstrings. Useful for getting
-        the correct version of wrapped functions. Defaults to
-        `f"{f.__module__}.{f.__name__}"`.
+            the correct version of wrapped functions. Defaults to
+            `f"{f.__module__}.{f.__name__}"`.
     """
 
     if f_name is None:

--- a/scico/linop/_linop.py
+++ b/scico/linop/_linop.py
@@ -33,8 +33,8 @@ def power_iteration(A: LinearOperator, maxiter: int = 100, key: Optional[PRNGKey
         A: :class:`.LinearOperator` used for computation. Must be
             diagonalizable.
         maxiter: Maximum number of power iterations to use.
-        key: Jax PRNG key. Defaults to None, in which case a new key is
-            created.
+        key: Jax PRNG key. Defaults to ``None``, in which case a new key
+            is created.
 
     Returns:
         tuple: A tuple (`mu`, `v`) containing:
@@ -77,11 +77,11 @@ def operator_norm(A: LinearOperator, maxiter: int = 100, key: Optional[PRNGKey] 
     Args:
         A: :class:`.LinearOperator` for which operator norm is desired.
         maxiter: Maximum number of power iterations to use. Default: 100
-        key: Jax PRNG key. Defaults to None, in which case a new key is
-            created.
+        key: Jax PRNG key. Defaults to ``None``, in which case a new key
+            is created.
 
     Returns:
-        float : Norm of operator :math:`A`.
+        float: Norm of operator :math:`A`.
 
     """
     return snp.sqrt(power_iteration(A.H @ A, maxiter, key)[0])
@@ -123,16 +123,16 @@ def valid_adjoint(
         A: Primary :class:`.LinearOperator`.
         AT: Adjoint :class:`.LinearOperator`.
         eps: Error threshold for validation of :math:`\mathsf{AT}` as
-           adjoint of :math:`\mathsf{AT}`. If None, the relative error
-           is returned instead of a boolean value.
-        x : If not the default None, use the specified array instead of a
-           random array as test vector :math:`\mb{x}`. If specified, the
-           array must have shape `A.input_shape`.
-        y : If not the default None, use the specified array instead of a
-           random array as test vector :math:`\mb{y}`. If specified, the
-           array must have shape `AT.input_shape`.
-        key: Jax PRNG key. Defaults to None, in which case a new key is
-           created.
+           adjoint of :math:`\mathsf{AT}`. If ``None``, the relative
+           error is returned instead of a boolean value.
+        x: If not the default ``None``, use the specified array instead
+           of a random array as test vector :math:`\mb{x}`. If specified,
+           the array must have shape `A.input_shape`.
+        y: If not the default ``None``, use the specified array instead
+           of a random array as test vector :math:`\mb{y}`. If specified,
+           the array must have shape `AT.input_shape`.
+        key: Jax PRNG key. Defaults to ``None``, in which case a new key
+           is created.
 
     Returns:
       Boolean value indicating whether validation passed, or relative
@@ -346,9 +346,10 @@ def linop_from_function(f: Callable, classname: str, f_name: Optional[str] = Non
                 Defaults to ``float32``. If `LinearOperator` implements
                 complex-valued operations, this must be ``complex64`` for
                 proper adjoint and gradient calculation.
-            jit: If ``True``, call :meth:`.jit()` on this LinearOperator
-                to jit the forward, adjoint, and gram functions. Same as
-                calling :meth:`.jit` after the LinearOperator is created.
+            jit: If ``True``, call :meth:`.Operator.jit` on this
+                `LinearOperator` to jit the forward, adjoint, and gram
+                functions. Same as calling :meth:`.Operator.jit` after
+                the `LinearOperator` is created.
             kwargs: Keyword arguments passed to :func:`{f_name}`.
         """
 

--- a/scico/linop/optics.py
+++ b/scico/linop/optics.py
@@ -214,8 +214,7 @@ class AngularSpectrumPropagator(Propagator):
         jit: bool = True,
         **kwargs,
     ):
-        r"""Angular Spectrum init method.
-
+        r"""
         Args:
             input_shape: Shape of input array. Can be a tuple of length
                2 or 3.
@@ -223,9 +222,10 @@ class AngularSpectrumPropagator(Propagator):
             k0: Illumination wavenumber.
             z: Propagation distance.
             pad_factor:  Amount of padding to apply in DFT step.
-            jit: If ``True``, call :meth:`.jit()` on this LinearOperator
-               to jit the forward, adjoint, and gram functions. Same as
-               calling :meth:`.jit` after the LinearOperator is created.
+            jit: If ``True``, call :meth:`.Operator.jit` on this
+               `LinearOperator` to jit the forward, adjoint, and gram
+               functions. Same as calling :meth:`.Operator.jit` after the
+               `LinearOperator` is created.
         """
 
         # Diagonal operator; phase shifting
@@ -425,7 +425,7 @@ class FraunhoferPropagator(LinearOperator):
             k0: Illumination wavenumber;  2π/wavelength.
             z: Propagation distance.
             jit: If ``True``, jit the evaluation, adjoint, and gram
-                functions of this LinearOperator. Default: True.
+               functions of this LinearOperator. Default: ``True``.
         """
 
         ndim = len(input_shape)  # 1 or 2 dimensions


### PR DESCRIPTION
Disable inclusion of inherited members in sphinx autodoc. Also address some sphinx warnings and style issues.