### PR TITLE
Make compatible with jax v0.3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy>=1.12
 scipy>=0.19.1
 imageio
 matplotlib
-jaxlib>=0.3.0,<=0.3.2
-jax>=0.3.0,<=0.3.4
+jaxlib>=0.3.0,<=0.3.5
+jax>=0.3.0,<=0.3.5
 flax>=0.4.0
 bm3d
 bm4d

--- a/scico/linop/_matrix.py
+++ b/scico/linop/_matrix.py
@@ -224,7 +224,7 @@ class MatrixOperator(LinearOperator):
 
     def to_array(self):
         """Return a :class:`numpy.ndarray` containing `self.A`."""
-        return self.A.copy()
+        return np.array(self.A)
 
     @property
     def gram_op(self):

--- a/scico/loss.py
+++ b/scico/loss.py
@@ -405,12 +405,12 @@ def _dep_cubic_root(p, q):
     (see Sec. 3.C of :cite:`soulez-2016-proximity`).
     """
     q2 = q / 2
-    Δ = q2 ** 2 + (p / 3) ** 3
+    Δ = q2**2 + (p / 3) ** 3
     Δrt = snp.sqrt(Δ + 0j)
     u3, v3 = -q2 + Δrt, -q2 - Δrt
     u, v = _cbrt(u3), _cbrt(v3)
     r = (u + v).real
-    assert snp.allclose(snp.abs(r ** 3 + p * r + q), 0, atol=1e-4)
+    assert snp.allclose(snp.abs(r**3 + p * r + q), 0, atol=1e-4)
     return r
 
 

--- a/scico/loss.py
+++ b/scico/loss.py
@@ -13,6 +13,8 @@ from copy import copy
 from functools import wraps
 from typing import Callable, Optional, Union
 
+import jax
+
 import scico.numpy as snp
 from scico import functional, linop, operator
 from scico.array import ensure_on_device, no_nan_divide
@@ -403,12 +405,12 @@ def _dep_cubic_root(p, q):
     (see Sec. 3.C of :cite:`soulez-2016-proximity`).
     """
     q2 = q / 2
-    Δ = q2**2 + (p / 3) ** 3
+    Δ = q2 ** 2 + (p / 3) ** 3
     Δrt = snp.sqrt(Δ + 0j)
     u3, v3 = -q2 + Δrt, -q2 - Δrt
     u, v = _cbrt(u3), _cbrt(v3)
     r = (u + v).real
-    assert snp.allclose(snp.abs(r**3 + p * r + q), 0, atol=1e-4)
+    assert snp.allclose(snp.abs(r ** 3 + p * r + q), 0, atol=1e-4)
     return r
 
 

--- a/scico/solver.py
+++ b/scico/solver.py
@@ -60,6 +60,8 @@ In the future, this module may be replaced with a dependency on
 from functools import wraps
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
+import numpy as np
+
 import jax
 
 import scico.numpy as snp
@@ -88,9 +90,9 @@ def _wrap_func(func: Callable, shape: Union[Shape, BlockShape], dtype: DType) ->
         # apply val_grad_func to un-vectorized input
         val = val_func(snp.reshape(x, shape).astype(dtype), *args)
 
-        # Convert val into numpy array (.copy()), then cast to float
+        # Convert val into numpy array, then cast to float
         # Convert 'val' into a scalar, rather than ndarray of shape (1,)
-        val = val.copy().astype(float).item()
+        val = np.array(val).astype(float).item()
         return val
 
     return wrapper
@@ -119,10 +121,10 @@ def _wrap_func_and_grad(func: Callable, shape: Union[Shape, BlockShape], dtype: 
         # apply val_grad_func to un-vectorized input
         val, grad = val_grad_func(snp.reshape(x, shape).astype(dtype), *args)
 
-        # Convert val & grad into numpy arrays (.copy()), then cast to float
+        # Convert val & grad into numpy arrays, then cast to float
         # Convert 'val' into a scalar, rather than ndarray of shape (1,)
-        val = val.copy().astype(float).item()
-        grad = grad.copy().astype(float).ravel()
+        val = np.array(val).astype(float).item()
+        grad = np.array(grad).astype(float).ravel()
         return val, grad
 
     return wrapper
@@ -210,7 +212,7 @@ def minimize(
     x0 = x0.ravel()  # if x0 is a BlockArray it will become a DeviceArray here
     if isinstance(x0, jax.interpreters.xla.DeviceArray):
         dev = x0.device_buffer.device()  # device for x0; used to put result back in place
-        x0 = x0.copy().astype(float)
+        x0 = np.array(x0).astype(float)
     else:
         dev = None
 

--- a/scico/test/functional/test_loss.py
+++ b/scico/test/functional/test_loss.py
@@ -32,7 +32,7 @@ class TestLoss:
         self.v, key = randn((n,), key=key, dtype=dtype)  # point for prox eval
         scalar, key = randn((1,), key=key, dtype=dtype)
         self.key = key
-        self.scalar = scalar.copy().ravel()[0]
+        self.scalar = scalar.item()
 
     def test_generic_squared_l2(self):
         A = linop.Identity(input_shape=self.y.shape)
@@ -40,7 +40,9 @@ class TestLoss:
         L0 = loss.Loss(self.y, A=A, f=f, scale=0.5)
         L1 = loss.SquaredL2Loss(y=self.y, A=A)
         np.testing.assert_allclose(L0(self.v), L1(self.v))
-        np.testing.assert_allclose(L0.prox(self.v, self.scalar), L1.prox(self.v, self.scalar))
+        np.testing.assert_allclose(
+            L0.prox(self.v, self.scalar), L1.prox(self.v, self.scalar), rtol=1e-6
+        )
 
     def test_generic_exception(self):
         A = linop.Diagonal(self.v)
@@ -136,7 +138,7 @@ class TestAbsLoss:
         self.x, key = randn((n,), key=key, dtype=complex_dtype(dtype))
         self.v, key = randn((n,), key=key, dtype=complex_dtype(dtype))  # point for prox eval
         scalar, key = randn((1,), key=key, dtype=dtype)
-        self.scalar = scalar.copy().ravel()[0]
+        self.scalar = scalar.item()
 
     @pytest.mark.parametrize("loss_tuple", abs_loss)
     def test_properties(self, loss_tuple):

--- a/scico/test/linop/test_linop.py
+++ b/scico/test/linop/test_linop.py
@@ -82,7 +82,7 @@ class LinearOperatorTestObj:
         self.x, key = randn((N,), dtype=dtype, key=key)
         self.y, key = randn((M,), dtype=dtype, key=key)
         scalar, key = randn((1,), dtype=dtype, key=key)
-        self.scalar = scalar.copy().ravel()[0]
+        self.scalar = scalar.item()
         self.Ao = AbsMatOp(self.A)
         self.Bo = AbsMatOp(self.B)
         self.Co = AbsMatOp(self.C)

--- a/scico/test/test_operator.py
+++ b/scico/test/test_operator.py
@@ -24,12 +24,12 @@ class AbsOperator(Operator):
 
 class SquareOperator(Operator):
     def _eval(self, x):
-        return x ** 2
+        return x**2
 
 
 class SumSquareOperator(Operator):
     def _eval(self, x):
-        return snp.sum(x ** 2)
+        return snp.sum(x**2)
 
 
 class OperatorTestObj:

--- a/scico/test/test_operator.py
+++ b/scico/test/test_operator.py
@@ -24,12 +24,12 @@ class AbsOperator(Operator):
 
 class SquareOperator(Operator):
     def _eval(self, x):
-        return x**2
+        return x ** 2
 
 
 class SumSquareOperator(Operator):
     def _eval(self, x):
-        return snp.sum(x**2)
+        return snp.sum(x ** 2)
 
 
 class OperatorTestObj:
@@ -45,7 +45,7 @@ class OperatorTestObj:
         self.mat = randn(self.A.input_shape, dtype=dtype, key=key)
         self.x, key = randn((N,), dtype=dtype, key=key)
         scalar, key = randn((1,), dtype=dtype, key=key)
-        self.scalar = scalar.copy().ravel()[0]
+        self.scalar = scalar.item()  # DeviceArray -> actual scalar
 
         self.z, key = randn((2 * N,), dtype=dtype, key=key)
 


### PR DESCRIPTION
The main problem was that `x.copy()` no longer turns a `DeviceArray` into an `ndarray`. Instead, use `np.array(x)` or `x.from_device()`.