### PR TITLE
Add Python 3.7 compatibility

### DIFF
--- a/scico/__init__.py
+++ b/scico/__init__.py
@@ -12,6 +12,27 @@ __version__ = "0.0.3.dev0"
 
 import sys
 
+# Python 3.7 compatibility
+try:
+    from math import prod
+    from typing import Literal
+
+    del Literal, prod
+except ImportError:
+    import typing
+
+    typing.Literal = typing.Any
+
+    import math
+    from functools import reduce
+    from operator import mul
+
+    # use a double lambda to bind reduce and mul right now
+    math.prod = (lambda fun, op: lambda iterable: fun(op, iterable, 1))(reduce, mul)
+
+    del typing, math, mul, reduce
+
+
 # isort: off
 from ._autograd import grad, jacrev, linear_adjoint, value_and_grad
 

--- a/scico/__init__.py
+++ b/scico/__init__.py
@@ -12,26 +12,7 @@ __version__ = "0.0.3.dev0"
 
 import sys
 
-# Python 3.7 compatibility
-try:
-    from math import prod
-    from typing import Literal
-
-    del Literal, prod
-except ImportError:
-    import typing
-
-    typing.Literal = typing.Any  # type: ignore
-
-    import math
-    from functools import reduce
-    from operator import mul
-
-    # use a double lambda to bind reduce and mul right now
-    math.prod = (lambda fun, op: lambda iterable: fun(op, iterable, 1))(reduce, mul)  # type: ignore
-
-    del typing, math, mul, reduce
-
+from . import _python37  # python 3.7 compatibility
 
 # isort: off
 from ._autograd import grad, jacrev, linear_adjoint, value_and_grad

--- a/scico/__init__.py
+++ b/scico/__init__.py
@@ -21,14 +21,14 @@ try:
 except ImportError:
     import typing
 
-    typing.Literal = typing.Any
+    typing.Literal = typing.Any  # type: ignore
 
     import math
     from functools import reduce
     from operator import mul
 
     # use a double lambda to bind reduce and mul right now
-    math.prod = (lambda fun, op: lambda iterable: fun(op, iterable, 1))(reduce, mul)
+    math.prod = (lambda fun, op: lambda iterable: fun(op, iterable, 1))(reduce, mul)  # type: ignore
 
     del typing, math, mul, reduce
 

--- a/scico/_python37.py
+++ b/scico/_python37.py
@@ -11,7 +11,7 @@ This file should be removed when/if Colab upgrades to Python 3.8.
 
 import sys
 
-if sys.version_info.minor == 7:
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
     import typing
 
     typing.Literal = typing.Any  # type: ignore

--- a/scico/_python37.py
+++ b/scico/_python37.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021-2022 by SCICO Developers
+# All rights reserved. BSD 3-clause License.
+# This file is part of the SCICO package. Details of the copyright and
+# user license can be found in the 'LICENSE' file distributed with the
+# package.
+
+""" Alter the behavior of (monkey patch) several modules so that SCICO
+is compatible with Python 3.7, allowing it to run on Google Colab.
+This file should be removed when/if Colab upgrades to Python 3.8.
+"""
+
+import sys
+
+if sys.version_info.minor == 7:
+    import typing
+
+    typing.Literal = typing.Any  # type: ignore
+
+    import math
+    from functools import reduce
+    from operator import mul
+
+    # math.prod = (lambda fun, op: lambda iterable: fun(op, iterable, 1))(reduce, mul)  # type: ignore
+    math.prod = lambda iterable: reduce(mul, iterable, 1)  # type: ignore

--- a/scico/_version.py
+++ b/scico/_version.py
@@ -42,7 +42,7 @@ def variable_assign_value(path: str, var: str) -> Any:
         try:
             # See http://stackoverflow.com/questions/2058802
             value_obj = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value  # type: ignore
-            if sys.version_info.minor == 7:
+            if sys.version_info.major == 3 and sys.version_info.minor == 7:
                 value = value_obj.n  # type: ignore
             else:
                 value = value_obj.s  # type: ignore

--- a/scico/_version.py
+++ b/scico/_version.py
@@ -41,7 +41,11 @@ def variable_assign_value(path: str, var: str) -> Any:
     with open(path) as f:
         try:
             # See http://stackoverflow.com/questions/2058802
-            value = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value.s  # type: ignore
+            value_obj = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value
+            try:
+                value = value_obj.s  # type: ignore
+            except AttributeError:  # Python 3.7 s -> n
+                value = value_obj.n
         except StopIteration:
             raise RuntimeError(f"Could not find initialization of variable {var}")
     return value

--- a/scico/_version.py
+++ b/scico/_version.py
@@ -7,9 +7,9 @@
 
 """Support functions for determining the package version."""
 
-
 import os
 import re
+import sys
 from ast import parse
 from subprocess import PIPE, Popen
 from typing import Any, Optional, Tuple, Union
@@ -42,10 +42,11 @@ def variable_assign_value(path: str, var: str) -> Any:
         try:
             # See http://stackoverflow.com/questions/2058802
             value_obj = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value  # type: ignore
-            try:
+            if sys.version_info.minor == 7:
+                value = value_obj.n  # type: ignore
+            else:
                 value = value_obj.s  # type: ignore
-            except AttributeError:  # Python 3.7 s -> n
-                value = value_obj.n
+
         except StopIteration:
             raise RuntimeError(f"Could not find initialization of variable {var}")
     return value

--- a/scico/_version.py
+++ b/scico/_version.py
@@ -41,7 +41,7 @@ def variable_assign_value(path: str, var: str) -> Any:
     with open(path) as f:
         try:
             # See http://stackoverflow.com/questions/2058802
-            value_obj = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value
+            value_obj = parse(next(filter(lambda line: line.startswith(var), f))).body[0].value  # type: ignore
             try:
                 value = value_obj.s  # type: ignore
             except AttributeError:  # Python 3.7 s -> n

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import operator
 import warnings
-from functools import reduce
+from math import prod
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
@@ -17,11 +16,6 @@ import scico.numpy as snp
 from scico.typing import ArrayIndex, Axes, AxisIndex, BlockShape, DType, JaxArray, Shape
 
 from ._blockarray import BlockArray
-
-
-def prod(iterable):
-    """Replacement for math.prod for Python 3.7."""
-    return reduce(operator.mul, iterable, 1)
 
 
 def ensure_on_device(

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import operator
 import warnings
-from math import prod
+from functools import reduce
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
@@ -16,6 +17,11 @@ import scico.numpy as snp
 from scico.typing import ArrayIndex, Axes, AxisIndex, BlockShape, DType, JaxArray, Shape
 
 from ._blockarray import BlockArray
+
+
+def prod(iterable):
+    """Replacement for math.prod for Python 3.7."""
+    return reduce(operator.mul, iterable, 1)
 
 
 def ensure_on_device(

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if jax_ver != req_jax_ver:
         f"requirements.txt ({req_jax_ver}) do not match"
     )
 
-python_requires = ">=3.8"
+python_requires = ">=3.7"
 tests_require = ["pytest", "pytest-runner"]
 
 extra_require_files = [


### PR DESCRIPTION
Three main changes:
- add `math.prod` if it doesn't exist
- add `typing.Literal` if it doesn't exist
- change syntax of `parse` call in `_version.py` if it fails