### PR TITLE
Resolve import error

### DIFF
--- a/scico/numpy/__init__.py
+++ b/scico/numpy/__init__.py
@@ -21,7 +21,7 @@ import numpy as np
 
 import jax.numpy as jnp
 
-from . import _wrappers
+from . import _wrappers, util
 from ._blockarray import BlockArray
 from ._wrapped_function_lists import *
 


### PR DESCRIPTION
Running the tests manually on the command line results in the error
```
>       if snp.util.is_complex_dtype(x0.dtype):
E       AttributeError: module 'scico.numpy' has no attribute 'util'
```
This is resolved by importing `util.py` in `scico/numpy/__init__.py`.

It isn't clear why this did not trigger an error in the CI tests.
