### PR TITLE
Extend interface of `linop.DFT`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Version 0.0.3   (unreleased)
 • New Huber norm (``HuberNorm``) and set distance functionals (``SetDistance`` and ``SquaredSetDistance``).
 • New loss functions ``loss.SquaredL2AbsLoss`` and ``loss.SquaredL2SquaredAbsLoss`` for phase retrieval problems.
 • Add interface to BM4D denoiser.
-• Change interface of ``linop.FiniteDifference``.
+• Change interfaces of ``linop.FiniteDifference`` and ``linop.DFT``.
 • Change filenames of some example scripts (and corresponding notebooks).
 • Change required packages and version numbers.
 • Add support for Python 3.7.

--- a/scico/linop/_dft.py
+++ b/scico/linop/_dft.py
@@ -5,7 +5,7 @@
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""Fourier transform linear operator class."""
+"""Discrete Fourier transform linear operator class."""
 
 
 # Needed to annotate a class method that returns the encapsulating class;
@@ -23,64 +23,78 @@ from ._linop import LinearOperator
 
 
 class DFT(LinearOperator):
-    r"""N-dimensional Discrete Fourier Transform."""
+    r"""Multi-dimensional discrete Fourier transform."""
 
     def __init__(
-        self, input_shape: Shape, output_shape: Optional[Shape] = None, jit: bool = True, **kwargs
+        self,
+        input_shape: Shape,
+        axes: Optional[Sequence] = None,
+        axes_shape: Optional[Shape] = None,
+        norm: Optional[str] = None,
+        jit: bool = True,
+        **kwargs,
     ):
         r"""
         Args:
             input_shape: Shape of input array.
-            output_shape: Shape of transformed output. Along any axis,
-                if the given output_shape is larger than the input, the
-                input is padded with zeros. If None, the shape of the
-                input is used.
+            axes: Axes over which to compute the DFT. If ``None``, the
+                DFT is computed over all axes.
+            axes_shape: Output shape on the subset of array axes selected
+                by `axes`. This parameter has the same behavior as the
+                `s` parameter of :func:`snp.fft.fftn`.
+            norm: DFT normalization mode. See `norm` parameter of
+                :func:`snp.fft.fftn`.
             jit: If ``True``, jit the evaluation, adjoint, and gram
                 functions of the LinearOperator.
         """
+        if axes is not None and axes_shape is not None and len(axes) != len(axes_shape):
+            raise ValueError(
+                f"len(axes)={len(axes)} does not equal len(axes_shape)={len(axes_shape)}"
+            )
 
-        if output_shape is None:
+        if axes_shape is not None:
+            if axes is None:
+                axes = tuple(range(len(input_shape) - len(axes_shape), len(input_shape)))
+            output_shape = list(input_shape)
+            for i, s in zip(axes, axes_shape):
+                output_shape[i] = s
+            output_shape = tuple(output_shape)
+        else:
             output_shape = input_shape
 
-        if len(output_shape) != len(input_shape):
-            raise ValueError(
-                f"len(output_shape)={len(output_shape)} does not equal "
-                f"len(input_shape)={len(input_shape)}"
-            )
+        if axes is None or axes_shape is None:
+            self.inv_axes_shape = None
+        else:
+            self.inv_axes_shape = [input_shape[i] for i in axes]
+
+        self.axes = axes
+        self.axes_shape = axes_shape
+        self.norm = norm
 
         # To satisfy mypy -- DFT shapes must be tuples, not list of tuple
         # These get set inside of super().__init__ call, but we want to have
         # more restrictive type than the general LinearOperator
-        self.output_shape: Shape = output_shape
-        self.input_shape: Shape = input_shape
+        self.input_shape: Shape
+        self.output_shape: Shape
 
         super().__init__(
             input_shape=input_shape,
+            output_shape=output_shape,
             input_dtype=np.complex64,
             output_dtype=np.complex64,
-            output_shape=output_shape,
             jit=jit,
             **kwargs,
         )
 
     def _eval(self, x: JaxArray) -> JaxArray:
-        return snp.fft.fftn(x, s=self.output_shape)
+        return snp.fft.fftn(x, s=self.axes_shape, axes=self.axes, norm=self.norm)
 
-    def inv(self, z: JaxArray, truncate: bool = True) -> JaxArray:
+    def inv(self, z: JaxArray) -> JaxArray:
         """Compute the inverse of this LinearOperator.
 
         Compute the inverse of this LinearOperator applied to `z`.
 
         Args:
-            z: Array to take inverse DFT.
-            truncate: If `True`, the inverse DFT is truncated to be
-               `input_shape`. This may be used when this DFT
-               LinearOperator applies zero padding before computing the
-               DFT.
+            z: Input array to inverse DFT.
         """
-        y = snp.fft.ifftn(z)
-        if truncate:
-            for i, s in enumerate(self.input_shape):
-                y = snp.take(y, indices=np.r_[:s], axis=i)
-
-        return y
+        return snp.fft.ifftn(z, s=self.inv_axes_shape, axes=self.axes, norm=self.norm)

--- a/scico/linop/_dft.py
+++ b/scico/linop/_dft.py
@@ -12,7 +12,7 @@
 # see https://www.python.org/dev/peps/pep-0563/
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 
@@ -41,9 +41,9 @@ class DFT(LinearOperator):
                 DFT is computed over all axes.
             axes_shape: Output shape on the subset of array axes selected
                 by `axes`. This parameter has the same behavior as the
-                `s` parameter of :func:`snp.fft.fftn`.
-            norm: DFT normalization mode. See `norm` parameter of
-                :func:`snp.fft.fftn`.
+                `s` parameter of :func:`numpy.fft.fftn`.
+            norm: DFT normalization mode. See the `norm` parameter of
+                :func:`numpy.fft.fftn`.
             jit: If ``True``, jit the evaluation, adjoint, and gram
                 functions of the LinearOperator.
         """

--- a/scico/linop/_dft.py
+++ b/scico/linop/_dft.py
@@ -55,10 +55,10 @@ class DFT(LinearOperator):
         if axes_shape is not None:
             if axes is None:
                 axes = tuple(range(len(input_shape) - len(axes_shape), len(input_shape)))
-            output_shape = list(input_shape)
+            tmp_output_shape = list(input_shape)
             for i, s in zip(axes, axes_shape):
-                output_shape[i] = s
-            output_shape = tuple(output_shape)
+                tmp_output_shape[i] = s
+            output_shape = tuple(tmp_output_shape)
         else:
             output_shape = input_shape
 

--- a/scico/linop/optics.py
+++ b/scico/linop/optics.py
@@ -180,7 +180,7 @@ class Propagator(LinearOperator):
         self.z: float = z
 
         # Fourier operator
-        self.F = DFT(input_shape=input_shape, output_shape=self.padded_shape, jit=False)
+        self.F = DFT(input_shape=input_shape, axes_shape=self.padded_shape, jit=False)
 
         # Diagonal operator; phase shifting
         self.D: LinearOperator = Identity(self.kp.shape)
@@ -540,7 +540,7 @@ class FraunhoferPropagator(LinearOperator):
         phase *= np.prod(dx)  # from approximating continouous FT with DFT
         phase = phase.astype(np.complex64)
 
-        self.F = DFT(input_shape=input_shape, output_shape=input_shape, jit=False)
+        self.F = DFT(input_shape=input_shape, jit=False)
         self.D = Diagonal(phase)
         super().__init__(
             input_shape=input_shape,


### PR DESCRIPTION
Extend interface of `linop.DFT`. Resolves #298.