### PR TITLE
Extend L21Norm to support multiple l2 axes

### DIFF
--- a/scico/test/functional/test_misc.py
+++ b/scico/test/functional/test_misc.py
@@ -65,3 +65,25 @@ def test_scalar_pmap():
     non_pmap = np.array([foo(c) for c in c_list])
     pmapped = jax.pmap(foo)(c_list)
     np.testing.assert_allclose(non_pmap, pmapped)
+
+
+@pytest.mark.parametrize("axis", [0, 1, (0, 2)])
+def test_l21norm(axis):
+    x = np.ones((3, 4, 5))
+    if isinstance(axis, int):
+        l2axis = (axis,)
+    else:
+        l2axis = axis
+    l2shape = [x.shape[k] for k in l2axis]
+    l1axis = tuple(set(range(len(x))) - set(l2axis))
+    l1shape = [x.shape[k] for k in l1axis]
+
+    l21ana = np.sqrt(np.prod(l2shape)) * np.prod(l1shape)
+    F = functional.L21Norm(l2_axis=axis)
+    l21num = F(x)
+    np.testing.assert_allclose(l21ana, l21num, rtol=1e-5)
+
+    l2ana = np.sqrt(np.prod(l2shape))
+    prxana = (l2ana - 1.0) / l2ana * x
+    prxnum = F.prox(x, 1.0)
+    np.testing.assert_allclose(prxana, prxnum, rtol=1e-5)


### PR DESCRIPTION
Extend `functional.L21Norm` to support multiple l2 axes. Resolves #310.