### PR TITLE
Fix support for building docs offline

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,12 +120,12 @@ if os.environ.get("NO_MATHJAX"):
     imgmath_image_format = "svg"
 else:
     extensions.append("sphinx.ext.mathjax")
+    # To use local copy of MathJax for offline use, set MATHJAX_URI to
+    #   file:///[path-to-mathjax-repo-root]/es5/tex-chtml-full.js?config=TeX-AMS_HTML
     if os.environ.get("MATHJAX_URI"):
         mathjax_path = os.environ.get("MATHJAX_URI")
-    else:
-        mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"
 
-mathjax_config = {
+mathjax2_config = {
     "TeX": {
         "Macros": {
             "mb": [r"\mathbf{#1}", 1],
@@ -142,6 +142,8 @@ mathjax_config = {
         }
     }
 }
+
+mathjax3_config = {"tex": {"macros": mathjax2_config["TeX"]["Macros"]}}
 
 
 # See https://stackoverflow.com/questions/5599254
@@ -256,7 +258,7 @@ latex_engine = "xelatex"
 # latex_use_xindy = False
 
 latex_macros = []
-for k, v in mathjax_config["TeX"]["Macros"].items():
+for k, v in mathjax2_config["TeX"]["Macros"].items():
     if len(v) == 1:
         latex_macros.append(r"\newcommand{\%s}{%s}" % (k, v[0]))
     else:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,19 +114,20 @@ nbsphinx_prolog = """
 #  https://github.com/JamesALeedham/Sphinx-Autosummary-Recursion
 autosummary_generate = True
 
+
 if os.environ.get("NO_MATHJAX"):
     extensions.append("sphinx.ext.imgmath")
     imgmath_image_format = "svg"
 else:
     extensions.append("sphinx.ext.mathjax")
     # To use local copy of MathJax for offline use, set MATHJAX_URI to
-    #   file:///[path-to-mathjax-repo-root]/es5/tex-chtml-full.js?config=TeX-AMS_HTML
+    #    file:///[path-to-mathjax-repo-root]/es5/tex-mml-chtml.js
     if os.environ.get("MATHJAX_URI"):
         mathjax_path = os.environ.get("MATHJAX_URI")
 
-mathjax2_config = {
-    "TeX": {
-        "Macros": {
+mathjax3_config = {
+    "tex": {
+        "macros": {
             "mb": [r"\mathbf{#1}", 1],
             "mbs": [r"\boldsymbol{#1}", 1],
             "mbb": [r"\mathbb{#1}", 1],
@@ -142,10 +143,8 @@ mathjax2_config = {
     }
 }
 
-mathjax3_config = {"tex": {"macros": mathjax2_config["TeX"]["Macros"]}}
-
 latex_macros = []
-for k, v in mathjax2_config["TeX"]["Macros"].items():
+for k, v in mathjax3_config["tex"]["macros"].items():
     if len(v) == 1:
         latex_macros.append(r"\newcommand{\%s}{%s}" % (k, v[0]))
     else:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,6 @@ nbsphinx_prolog = """
 #  https://github.com/JamesALeedham/Sphinx-Autosummary-Recursion
 autosummary_generate = True
 
-# Copied from scikit-learn sphinx configuration
 if os.environ.get("NO_MATHJAX"):
     extensions.append("sphinx.ext.imgmath")
     imgmath_image_format = "svg"
@@ -144,6 +143,15 @@ mathjax2_config = {
 }
 
 mathjax3_config = {"tex": {"macros": mathjax2_config["TeX"]["Macros"]}}
+
+latex_macros = []
+for k, v in mathjax2_config["TeX"]["Macros"].items():
+    if len(v) == 1:
+        latex_macros.append(r"\newcommand{\%s}{%s}" % (k, v[0]))
+    else:
+        latex_macros.append(r"\newcommand{\%s}[1]{%s}" % (k, v[0]))
+
+imgmath_latex_preamble = "\n".join(latex_macros)
 
 
 # See https://stackoverflow.com/questions/5599254
@@ -252,17 +260,9 @@ latex_documents = [
     ("index", "scico.tex", "SCICO Documentation", "The SCICO Developers", "manual"),
 ]
 
-
 latex_engine = "xelatex"
 
 # latex_use_xindy = False
-
-latex_macros = []
-for k, v in mathjax2_config["TeX"]["Macros"].items():
-    if len(v) == 1:
-        latex_macros.append(r"\newcommand{\%s}{%s}" % (k, v[0]))
-    else:
-        latex_macros.append(r"\newcommand{\%s}[1]{%s}" % (k, v[0]))
 
 latex_elements = {"preamble": "\n".join(latex_macros)}
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
     "sphinx.ext.inheritance_diagram",
-    "sphinx.ext.mathjax",
     "sphinx.ext.todo",
     "nbsphinx",
 ]
@@ -121,7 +120,10 @@ if os.environ.get("NO_MATHJAX"):
     imgmath_image_format = "svg"
 else:
     extensions.append("sphinx.ext.mathjax")
-    mathjax_path = "https://cdn.mathjax.org/mathjax/latest/" "MathJax.js?config=TeX-AMS_HTML"
+    if os.environ.get("MATHJAX_URI"):
+        mathjax_path = os.environ.get("MATHJAX_URI")
+    else:
+        mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"
 
 mathjax_config = {
     "TeX": {
@@ -226,7 +228,7 @@ else:
 # Output file base name for HTML help builder.
 htmlhelp_basename = "SCICOdoc"
 
-# Include TOODs
+# Include TODOs
 todo_include_todos = True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ scipy>=1.6.0
 tifffile
 imageio>=2.17
 matplotlib
-jaxlib>=0.3.0,<=0.3.15
-jax>=0.3.0,<=0.3.17
+jaxlib>=0.3.0,<=0.3.22
+jax>=0.3.0,<=0.3.23
 flax>=0.4.0
 bm3d>=3.0.9
 svmbir>=0.3.0


### PR DESCRIPTION
Fix support for building docs offline, allowing use of `sphinx.ext.imgmath` extension for equations, or specification of a local MathJax path for use with `sphinx.ext.mathjax`.

Also bump supported jaxlib/jax versions.