### PR TITLE
Update dependencies

### DIFF
--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -1,5 +1,4 @@
 astra-toolbox
-bm4d>=4.0.0
 colour_demosaicing
 xdesign>=0.5.5
 ray[tune]>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ scipy>=1.6.0
 tifffile
 imageio>=2.17
 matplotlib
-jaxlib>=0.3.0,<=0.3.24
-jax>=0.3.0,<=0.3.24
+jaxlib>=0.3.0,<=0.3.25
+jax>=0.3.0,<=0.3.25
 flax>=0.4.0
-bm3d>=3.0.9
+bm3d>=4.0.0
+bm4d>=4.2.2
 svmbir>=0.3.0
 pyabel>=0.8.5

--- a/scico/denoiser.py
+++ b/scico/denoiser.py
@@ -5,26 +5,8 @@
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""
-Interfaces to standard denoisers.
+"""Interfaces to standard denoisers."""
 
-**Warning**: The :func:`bm4d` function is implemented as an interface
-to the `bm4d <https://pypi.org/project/bm4d>`__ package. The current
-version of this package, 4.0.0, appears to be compiled with compiler
-options that `change the behavior of the floating point unit
-<https://moyix.blogspot.com/2022/09/someones-been-messing-with-my-subnormals.html>`__
-in a way that results in lower numerical accuracy, and that persist
-for the duration of the process that loads it. If this package is
-installed, simply loading this module (:mod:`scico.denoiser`), is
-sufficient to inflict this loss of numerical precision on all other
-calculations run within the same process, even if :func:`bm4d` is not
-actually used. Users who are not making use of :func:`bm4d` are
-advised not to install the corresponding package. For additional
-information, see `scico issue #342
-<https://github.com/lanl/scico/issues/342>`__.
-"""
-
-import warnings
 
 import numpy as np
 
@@ -43,19 +25,6 @@ except ImportError:
     have_bm4d = False
 else:
     have_bm4d = True
-    finfo = np.finfo(np.float32)  # type: ignore
-    if hasattr(finfo, "smallest_subnormal"):  # can't test with older numpy versions
-        if finfo.smallest_subnormal == 0.0:
-            warnings.warn(
-                "Importing module bm4d has had an adverse affect on floating point "
-                "accuracy. See the documentation for module scico.denoiser, and "
-                "scico issue #342."
-            )
-            warnings.filterwarnings(
-                action="ignore",
-                message="^The value of the smallest subnormal",
-                category=UserWarning,
-            )
 
 import scico.numpy as snp
 from scico._flax import DnCNNNet, load_weights


### PR DESCRIPTION
- Bump maximum `jaxlib`/`jax` versions.
- Bump minimum `bm3d`/`bm4d` versions to exclude versions with problematic subnormal float handling.
- Remove warning and test related to subnormal float handling issue.
- Move `bm4d` to main requirements file.

Resolves recent failure of `unit tests -- latest jax` test in CI.
