### PR TITLE
Add checking for unrecognized keyword arguments

### DIFF
--- a/scico/optimize/_common.py
+++ b/scico/optimize/_common.py
@@ -102,6 +102,9 @@ class Optimizer:
         itstat_options = kwargs.pop("itstat_options", None)
         self.maxiter: int = kwargs.pop("maxiter", 100)
 
+        if kwargs:
+            raise TypeError(f"Unrecognized keyword argument(s) {', '.join([k for k in kwargs])}")
+
         self.itnum: int = 0
         self.timer: Timer = Timer()
 

--- a/scico/test/optimize/test_admm.py
+++ b/scico/test/optimize/test_admm.py
@@ -2,6 +2,8 @@ import numpy as np
 
 import jax
 
+import pytest
+
 import scico.numpy as snp
 from scico import functional, linop, loss, metric, random
 from scico.optimize import ADMM
@@ -40,6 +42,7 @@ class TestMisc:
         )
         assert len(admm_.itstat_object.fieldname) == 6
         assert snp.sum(admm_.x) == 0.0
+
         admm_ = ADMM(
             f=f,
             g_list=[g],
@@ -57,6 +60,9 @@ class TestMisc:
 
         x = admm_.solve(callback=callback)
         assert admm_.test_flag
+
+        with pytest.raises(TypeError):
+            admm_ = ADMM(f=f, g_list=[g], C_list=[C], rho_list=[ρ], invalid_keyword_arg=None)
 
 
 class TestReal:


### PR DESCRIPTION
Optimiser class `__init__` methods currently just ignore unrecognized keyword arguments. This PR adds such checking to avoid user confusion etc. when there is a typo in an argument name , which could lead to unexpected behaviour.