### PR TITLE
Fix a few typos in docstrings and an example

### DIFF
--- a/examples/scripts/deconv_tv_admm.py
+++ b/examples/scripts/deconv_tv_admm.py
@@ -67,7 +67,7 @@ operator. This problem can be expressed as
 
   $$\mathrm{argmin}_{\mathbf{x}, \mathbf{z}} \; (1/2) \| \mathbf{y} -
   C \mathbf{x} \|_2^2 + \lambda \| \mathbf{z} \|_{2,1} \;\;
-  \text{such that} \;\; \mathbf{z} = C \mathbf{x} \;,$$
+  \text{such that} \;\; \mathbf{z} = D \mathbf{x} \;,$$
 
 which is easily written in the form of a standard ADMM problem.
 

--- a/scico/optimize/_padmm.py
+++ b/scico/optimize/_padmm.py
@@ -173,7 +173,7 @@ class ProximalADMM(ProximalADMMBase):
         \text{such that}\; A \mb{x} + B \mb{z} = \mb{c} \;,
 
     where :math:`f` and :math:`g` are instances of :class:`.Functional`,
-    (in most cases :math:`f` will, more specifically be an an instance
+    (in most cases :math:`f` will, more specifically be an instance
     of :class:`.Loss`), and :math:`A` and :math:`B` are instances of
     :class:`LinearOperator`.
 
@@ -403,7 +403,7 @@ class NonLinearPADMM(ProximalADMMBase):
         \text{such that}\; H(\mb{x}, \mb{z}) = 0 \;,
 
     where :math:`f` and :math:`g` are instances of :class:`.Functional`,
-    (in most cases :math:`f` will, more specifically be an an instance
+    (in most cases :math:`f` will, more specifically be an instance
     of :class:`.Loss`), and :math:`H` is a function.
 
     The optimization problem is solved via a variant of the proximal ADMM


### PR DESCRIPTION
Firstly, thanks for the great package!
Just a few typos I spotted in the docs, hope you don't mind such tiny PRs