### PR TITLE
Make adjoint and gram get auto set separately 

### DIFF
--- a/scico/linop/radon_astra.py
+++ b/scico/linop/radon_astra.py
@@ -86,10 +86,10 @@ class TomographicProjector(LinearOperator):
         # Set up all the ASTRA config
         self.detector_spacing: float = detector_spacing
         self.det_count: int = det_count
-        self.angles: np.ndarray = angles
+        self.angles: np.ndarray = np.array(angles)
 
         self.proj_geom: dict = astra.create_proj_geom(
-            "parallel", detector_spacing, det_count, angles
+            "parallel", detector_spacing, det_count, self.angles
         )
         self.proj_id: int
         self.input_shape: tuple = input_shape

--- a/scico/test/linop/test_radon_astra.py
+++ b/scico/test/linop/test_radon_astra.py
@@ -1,10 +1,10 @@
-import numpy as np
-
 import jax
 
 import pytest
 
 import scico
+import scico.numpy as snp
+from scico.linop import DiagonalStack
 from scico.test.linop.test_linop import adjoint_test
 from scico.test.linop.test_radon_svmbir import make_im
 
@@ -118,3 +118,9 @@ def test_adjoint_typical_input(testobj):
     x = make_im(A.input_shape[0], A.input_shape[1], is_3d=False)
 
     adjoint_test(A, x=x, rtol=get_tol())
+
+
+def test_jit_in_DiagonalStack():
+    N = 10
+    H = DiagonalStack([TomographicProjector((N, N), 1.0, N, snp.linspace(0, snp.pi, N))])
+    H.T @ snp.zeros(H.output_shape, dtype=snp.float32)

--- a/scico/test/linop/test_radon_astra.py
+++ b/scico/test/linop/test_radon_astra.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import jax
 
 import pytest
@@ -121,6 +123,7 @@ def test_adjoint_typical_input(testobj):
 
 
 def test_jit_in_DiagonalStack():
+    """See https://github.com/lanl/scico/issues/331"""
     N = 10
     H = DiagonalStack([TomographicProjector((N, N), 1.0, N, snp.linspace(0, snp.pi, N))])
     H.T @ snp.zeros(H.output_shape, dtype=snp.float32)

--- a/scico/test/linop/test_radon_svmbir.py
+++ b/scico/test/linop/test_radon_svmbir.py
@@ -374,4 +374,4 @@ def test_approx_prox(
 
     xprox_approx = snp.array(f_approx.prox(v, lam=λ, v0=xprox))
 
-    assert snp.linalg.norm(xprox - xprox_approx) / snp.linalg.norm(xprox) < 4e-6
+    assert snp.linalg.norm(xprox - xprox_approx) / snp.linalg.norm(xprox) < 5e-5


### PR DESCRIPTION
Previously, when a LinOp needed _either_  a gram operator _or_ an adjoint, both would be automatically generated. In particular, this meant that user-defined adjoint would be overwritten if the user did not also set the gram. This PR splits the two.

Addresses #331