### PR TITLE
Remove Edit on Github button (again)

### DIFF
--- a/docs/source/_templates/breadcrumbs.html
+++ b/docs/source/_templates/breadcrumbs.html
@@ -1,4 +1,0 @@
-{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
-
-{% block breadcrumbs_aside %}
-{% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,6 +220,7 @@ pygments_style = "sphinx"
 html_theme = "furo"
 
 html_theme_options = {
+    "top_of_page_button": None,
     # "sidebar_hide_name": True,
 }
 


### PR DESCRIPTION
Remove Edit on Github button, which re-appeared in switch to `furo` theme.