### PR TITLE
use GPU for FBP

### DIFF
--- a/examples/scripts/ct_astra3d_tv_admm.py
+++ b/examples/scripts/ct_astra3d_tv_admm.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of the SCICO package. Details of the copyright
+# and user license can be found in the 'LICENSE.txt' file distributed
+# with the package.
+
+r"""
+TV-Regularized Sparse-View CT Reconstruction
+============================================
+
+This example demonstrates solution of a sparse-view CT reconstruction
+problem with isotropic total variation (TV) regularization
+
+  $$\mathrm{argmin}_{\mathbf{x}} \; (1/2) \| \mathbf{y} - A \mathbf{x}
+  \|_2^2 + \lambda \| C \mathbf{x} \|_{2,1} \;,$$
+
+where $A$ is the Radon transform, $\mathbf{y}$ is the sinogram, $C$ is
+a 2D finite difference operator, and $\mathbf{x}$ is the desired
+image.
+"""
+
+import numpy as np
+
+import jax
+
+#from mpl_toolkits.axes_grid1 import make_axes_locatable
+#from xdesign import Foam, discrete_phantom
+
+import scico.numpy as snp
+from scico import functional, linop, loss, metric, plot
+from scico.linop.radon_astra3d import TomographicProjector3D
+from scico.optimize.admm import ADMM, LinearSubproblemSolver
+from scico.util import device_info
+
+def tangle_source(nx, ny, nz):
+    xs = 1. * np.linspace(-1., 1., nx)
+    ys = 1. * np.linspace(-1., 1., ny)
+    zs = 1. * np.linspace(-1., 1., nz)
+
+    # default ordering for meshgrid is `xy`, this makes inputs of length
+    # M, N, P will create a mesh of N, M, P. Thus we want ys, zs and xs.
+    xx, yy, zz = np.meshgrid(ys, zs, xs, copy=True)
+    xx = 3.0 * xx
+    yy = 3.0 * yy
+    zz = 3.0 * zz
+    values = (xx * xx * xx * xx -
+              5.0 * xx * xx + yy * yy * yy * yy -
+              5.0 * yy * yy + zz * zz * zz * zz -
+              5.0 * zz * zz + 11.8) * 0.2 + 0.5
+    return values
+
+Nx = 128
+Ny = 256
+Nz = 64
+
+tangle = tangle_source(Nx, Ny, Nz)
+tangle = jax.device_put(tangle)
+
+n_projection = 10  # number of projections
+angles = np.linspace(0, np.pi, n_projection)  # evenly spaced projection angles
+A = TomographicProjector3D(tangle.shape, 1.0, 1.0, Nz, max(Nx, Ny), angles)  # Radon transform operator
+y = A @ tangle   # sinogram
+
+
+"""
+Set up ADMM solver object.
+"""
+λ = 2e0  # L1 norm regularization parameter
+ρ = 5e0  # ADMM penalty parameter
+maxiter = 25  # number of ADMM iterations
+cg_tol = 1e-4  # CG relative tolerance
+cg_maxiter = 25  # maximum CG iterations per ADMM iteration
+
+# The append=0 option makes the results of horizontal and vertical
+# finite differences the same shape, which is required for the L21Norm,
+# which is used so that g(Cx) corresponds to isotropic TV.
+C = linop.FiniteDifference(input_shape=tangle.shape, append=0)
+g = λ * functional.L21Norm()
+
+f = loss.SquaredL2Loss(y=y, A=A)
+
+x0 = A.sirt(y)
+
+solver = ADMM(
+    f=f,
+    g_list=[g],
+    C_list=[C],
+    rho_list=[ρ],
+    x0=x0,
+    maxiter=maxiter,
+    subproblem_solver=LinearSubproblemSolver(cg_kwargs={"tol": cg_tol, "maxiter": cg_maxiter}),
+    itstat_options={"display": True, "period": 5},
+)
+
+"""
+Run the solver.
+"""
+print(f"Solving on {device_info()}\n")
+solver.solve()
+hist = solver.itstat_object.history(transpose=True)
+tangle_recon = solver.x
+
+print("SIRT Reconstruction\nSNR: %.2f (dB), MAE: %.3f" % (metric.snr(tangle, x0), metric.mae(tangle, x0)))
+print("TV Restruction\nSNR: %.2f (dB), MAE: %.3f" % (metric.snr(tangle, tangle_recon), metric.mae(tangle, tangle_recon)))

--- a/scico/linop/radon_astra.py
+++ b/scico/linop/radon_astra.py
@@ -198,7 +198,7 @@ class TomographicProjector(LinearOperator):
             # get the result
             out = astra.data2d.get(rec_id)
 
-            # cleanup FBP-specific arra
+            # cleanup FBP-specific arrays
             astra.algorithm.delete(alg_id)
             astra.data2d.delete(sino_id)
             astra.data2d.delete(rec_id)

--- a/scico/linop/radon_astra.py
+++ b/scico/linop/radon_astra.py
@@ -185,7 +185,7 @@ class TomographicProjector(LinearOperator):
             if dev0.platform == "gpu":
                 cfg = astra.astra_dict("FBP_CUDA")
             else:
-                cfg = astra.astra_dict('FBP"')
+                cfg = astra.astra_dict('FBP')
             cfg["ReconstructionDataId"] = rec_id
             cfg["ProjectorId"] = proj_id
             cfg["ProjectionDataId"] = sino_id

--- a/scico/linop/radon_astra3d.py
+++ b/scico/linop/radon_astra3d.py
@@ -1,0 +1,128 @@
+from typing import List, Optional
+
+import jax
+import jax.experimental.host_callback as hcb
+import numpy as np
+from astra import algorithm
+
+try:
+    import astra
+except ModuleNotFoundError as e:
+    if e.name == "astra":
+        new_e = ModuleNotFoundError("Could not import astra; please install the ASTRA toolbox.")
+        new_e.name = "astra"
+        raise new_e from e
+    else:
+        raise e
+
+from scico.typing import Shape
+
+from ._linop import LinearOperator
+
+
+class TomographicProjector3D(LinearOperator):
+    r"""
+    TBD
+    """
+
+    def __init__(
+            self,
+            input_shape: Shape,
+            detector_spacing_x: float,
+            detector_spacing_y: float,
+            detector_row_count: int,
+            detector_col_count: int,
+            angles: np.ndarray,
+            volume_geometry: Optional[List[float]] = None
+            # device can only be gpu
+    ):
+        """
+        TBD
+        """
+
+        self.detector_spacing_x: float = detector_spacing_x
+        self.detector_spacing_y: float = detector_spacing_y
+        self.detector_row_count: int = detector_row_count
+        self.detector_col_count: int = detector_col_count
+        self.angles: np.ndarray = angles
+
+        self.proj_geom = astra.create_proj_geom("parallel3d", detector_spacing_x, detector_spacing_y, detector_row_count,
+                                                detector_col_count, angles)
+        self.proj_id: int
+        self.input_shape: tuple = input_shape
+
+        if volume_geometry is not None:
+            if len(volume_geometry) == 6:
+                self.vol_geom: dict = astra.create_vol_geom(*input_shape, *volume_geometry)
+            else:
+                raise ValueError(
+                    "volume_geometry must be the shape of the volume as a tuple of len 6 "
+                    "containing the volume geometry dimensions. Please see documentation "
+                    "for details."
+                )
+        else:
+            (Nz, Ny, Nx) = input_shape
+            self.vol_geom = astra.create_vol_geom(Ny, Nx, Nz)
+
+        # hardcoded to use cuda3d (the only option), might not be necessary/needed
+        # self.proj_id = astra.create_projector("cuda3d", self.proj_geom, self.vol_geom)
+
+        # Wrap our non-jax function to indicate we will supply fwd/rev mode functions
+        self._eval = jax.custom_vjp(self._proj)
+        self._eval.defvjp(lambda x: (self._proj(x), None), lambda _, y: (self._bproj(y),))  # type: ignore
+        self._adj = jax.custom_vjp(self._bproj)
+        self._adj.defvjp(lambda y: (self._bproj(y), None), lambda _, x: (self._proj(x),))  # type: ignore
+
+        super().__init__(
+            input_shape=input_shape,
+            output_shape=(detector_row_count, len(angles), detector_col_count),
+            input_dtype=np.float32,
+            output_dtype=np.float32,
+            adj_fn=self._adj,
+            jit=False,
+        )
+
+    def _proj(self, x: jax.Array) -> jax.Array:
+        # Applies the forward projector and generates a sinogram
+        def f(x):
+            if not x.flags.writeable:
+                x.flags.writeable = True
+            proj_id, result = astra.create_sino3d_gpu(x, self.proj_geom, self.vol_geom)
+            astra.data3d.delete(proj_id)
+            return result
+
+        # print("output shape:", self.output_shape)
+        return hcb.call(f, x, result_shape=jax.ShapeDtypeStruct(self.output_shape, self.output_dtype))
+
+    def _bproj(self, y: jax.Array) -> jax.Array:
+        # applies backprojector
+        def f(y):
+            if not y.flags.writeable:
+                y.flags.writeable = True
+            proj_id, result = astra.create_backprojection3d_gpu(y, self.proj_geom, self.vol_geom)
+            astra.data3d.delete(proj_id)
+            return result
+
+        return hcb.call(f, y, result_shape=jax.ShapeDtypeStruct(self.input_shape, self.input_dtype))
+
+    def sirt(self, sino: jax.Array) -> jax.Array:
+        def f(sino):
+            if not sino.flags.writeable:
+                sino.flags.writeable = True
+            proj_id = astra.data3d.create('-sino', self.proj_geom, sino)
+            rec_id = astra.data3d.create('-vol', self.vol_geom)
+            cfg = astra.astra_dict('SIRT3D_CUDA')
+            cfg['ProjectionDataId'] = proj_id
+            cfg['ReconstructionDataId'] = rec_id
+            alg_id = algorithm.create(cfg)
+            algorithm.run(alg_id, 50)
+
+            out = astra.data3d.get(rec_id)
+
+            algorithm.delete(alg_id)
+            astra.data3d.delete(proj_id)
+            astra.data3d.delete(rec_id)
+
+            return out
+        # return f(sino)
+        return hcb.call(f, sino, result_shape=jax.ShapeDtypeStruct(self.input_shape, self.input_dtype))


### PR DESCRIPTION
I believe the reason for the "memory issue for GPU" is a missing `data2d.delete` (for the sinogram). This PR was tested on a Quadro RTX 4000 with cuda 11.8.