### PR TITLE
Add a jax-based X-ray projector

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -35,6 +35,7 @@ Computed Tomography
    examples/ct_astra_modl_train_foam2
    examples/ct_astra_odp_train_foam2
    examples/ct_astra_unet_train_foam2
+   examples/ct_projector_comparison
 
 
 Deconvolution

--- a/examples/scripts/README.rst
+++ b/examples/scripts/README.rst
@@ -35,6 +35,8 @@ Computed Tomography
       CT Training and Reconstructions with ODP
    `ct_astra_unet_train_foam2.py <ct_astra_unet_train_foam2.py>`_
       CT Training and Reconstructions with UNet
+   `ct_projector_comparison.py <ct_projector_comparison.py>`_
+      X-ray Projector Comparison
 
 
 Deconvolution

--- a/examples/scripts/ct_projector_comparison.py
+++ b/examples/scripts/ct_projector_comparison.py
@@ -93,6 +93,7 @@ as fast as ASTRA when both are run on the GPU, and about
 10% slower when both are run the CPU.
 
 On our server, using the GPU:
+```    
 Label               Accum.       Current
 -------------------------------------------
 astra_avg_proj      4.62e-02 s   Stopped
@@ -101,8 +102,10 @@ astra_init          1.36e-03 s   Stopped
 scico_avg_proj      1.61e-02 s   Stopped
 scico_first_proj    2.95e-02 s   Stopped
 scico_init          1.37e+01 s   Stopped
+```
 
 Using the CPU:
+```
 Label               Accum.       Current
 -------------------------------------------
 astra_avg_proj      9.11e-01 s   Stopped
@@ -111,6 +114,7 @@ astra_init          1.06e-03 s   Stopped
 scico_avg_proj      1.03e+00 s   Stopped
 scico_first_proj    1.04e+00 s   Stopped
 scico_init          1.00e+01 s   Stopped
+```
 """
 
 print(timer)
@@ -166,20 +170,24 @@ faster than ASTRA when both are run on the GPU,
 and about three times faster when both are run on the CPU.
 
 On our server, using the GPU:
+```
 Label             Accum.       Current
 -----------------------------------------
 astra_avg_BP      3.71e-02 s   Stopped
 astra_first_BP    4.20e-02 s   Stopped
 scico_avg_BP      1.05e-03 s   Stopped
 scico_first_BP    7.63e+00 s   Stopped
+```
 
 Using the CPU:
+```
 Label             Accum.       Current
 -----------------------------------------
 astra_avg_BP      9.34e-01 s   Stopped
 astra_first_BP    9.39e-01 s   Stopped
 scico_avg_BP      2.62e-01 s   Stopped
 scico_first_BP    1.00e+01 s   Stopped
+```
 """
 
 print(timer)

--- a/examples/scripts/ct_projector_comparison.py
+++ b/examples/scripts/ct_projector_comparison.py
@@ -89,8 +89,8 @@ for name, H in projectors.items():
 Display timing results.
 
 On our server, the SCICO projection is more than twice
-as fast as ASTRA when run on the GPU, and about about
-10% slower on the CPU.
+as fast as ASTRA when both are run on the GPU, and about
+10% slower when both are run the CPU.
 
 On our server, using the GPU:
 Label               Accum.       Current
@@ -111,9 +111,6 @@ astra_init          1.06e-03 s   Stopped
 scico_avg_proj      1.03e+00 s   Stopped
 scico_first_proj    1.04e+00 s   Stopped
 scico_init          1.00e+01 s   Stopped
-
-
-
 """
 
 print(timer)
@@ -162,15 +159,27 @@ for name, H in projectors.items():
 """
 Display back projection timing results.
 
-
+On our server, the SCICO back projection is slow
+the first time it is run, probably due to JIT overhead.
+After the first run, it is an order of magnitude
+faster than ASTRA when both are run on the GPU,
+and about three times faster when both are run on the CPU.
 
 On our server, using the GPU:
-
+Label             Accum.       Current
+-----------------------------------------
+astra_avg_BP      3.71e-02 s   Stopped
+astra_first_BP    4.20e-02 s   Stopped
+scico_avg_BP      1.05e-03 s   Stopped
+scico_first_BP    7.63e+00 s   Stopped
 
 Using the CPU:
-
-
-
+Label             Accum.       Current
+-----------------------------------------
+astra_avg_BP      9.34e-01 s   Stopped
+astra_first_BP    9.39e-01 s   Stopped
+scico_avg_BP      2.62e-01 s   Stopped
+scico_first_BP    1.00e+01 s   Stopped
 """
 
 print(timer)

--- a/examples/scripts/ct_projector_comparison.py
+++ b/examples/scripts/ct_projector_comparison.py
@@ -5,33 +5,45 @@
 # with the package.
 
 
-import time
+r"""
+X-ray Projector Comparison
+==========================
+
+This example compares SCICO's native X-ray projection algorithm
+to that of the ASTRA Toolbox.
+"""
 
 import jax
 import jax.numpy as jnp
+
 from xdesign import Foam, discrete_phantom
 
-from scico.linop import XRayProject, ParallelFixedAxis2dProjector
+from scico import plot
+from scico.linop import ParallelFixedAxis2dProjector, XRayProject
 from scico.linop.radon_astra import TomographicProjector
 from scico.util import Timer
 
+"""
+Create a ground truth image.
+"""
 
 N = 512
-num_angles = 512
+
 
 det_count = int(jnp.ceil(jnp.sqrt(2 * N**2)))
 
 x_gt = discrete_phantom(Foam(size_range=[0.075, 0.0025], gap=1e-3, porosity=1), size=N)
 x_gt = jax.device_put(x_gt)
 
+"""
+Time projector instantiation.
+"""
+
+num_angles = 500
 angles = jnp.linspace(0, jnp.pi, num=num_angles, endpoint=False)
 
-method_names = ["scico", "astra"]
-timer = Timer(
-    [n + "_init" for n in method_names]
-    + [n + "_first_proj" for n in method_names]
-    + [n + "_avg_proj" for n in method_names]
-)
+
+timer = Timer()
 
 projectors = {}
 timer.start("scico_init")
@@ -44,13 +56,22 @@ projectors["astra"] = TomographicProjector(
 )
 timer.stop("astra_init")
 
+"""
+Time first projector application, which might include JIT overhead.
+"""
+
 ys = {}
 for name, H in projectors.items():
     timer_label = f"{name}_first_proj"
     timer.start(timer_label)
     ys[name] = H @ x_gt
+    jax.block_until_ready(ys[name])
     timer.stop(timer_label)
 
+
+"""
+Compute average time for a projector application.
+"""
 
 num_repeats = 3
 for name, H in projectors.items():
@@ -58,28 +79,29 @@ for name, H in projectors.items():
     timer.start(timer_label)
     for _ in range(num_repeats):
         ys[name] = H @ x_gt
+        jax.block_until_ready(ys[name])
     timer.stop(timer_label)
     timer.td[timer_label] /= num_repeats
 
+"""
+Display timing results.
+
+On our server, using the GPU:
+
+
+Using the CPU:
+
+"""
 
 print(timer)
 
 """
-with way 2:
-Label               Accum.       Current
--------------------------------------------
-astra_avg_proj      7.30e-01 s   Stopped
-astra_first_proj    7.41e-01 s   Stopped
-astra_init          4.63e-03 s   Stopped
-scico_avg_proj      9.96e-01 s   Stopped
-scico_first_proj    9.98e-01 s   Stopped
-scico_init          8.02e+00 s   Stopped
+Show projections.
 """
 
-fig, ax = plt.subplots()
-ax.imshow(ys["scico"])
+fig, ax = plot.subplots(nrows=1, ncols=2, figsize=(7, 5))
+plot.imview(ys["scico"], title="SCICO projection", cbar=None, fig=fig, ax=ax[0])
+plot.imview(ys["astra"], title="ASTRA projection", cbar=None, fig=fig, ax=ax[1])
 fig.show()
 
-fig, ax = plt.subplots()
-ax.imshow(ys["astra"])
-fig.show()
+input("\nWaiting for input to close figures and exit")

--- a/examples/scripts/ct_projector_timing.py
+++ b/examples/scripts/ct_projector_timing.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of the SCICO package. Details of the copyright
+# and user license can be found in the 'LICENSE.txt' file distributed
+# with the package.
+
+
+import time
+
+import jax
+import jax.numpy as jnp
+from xdesign import Foam, discrete_phantom
+
+from scico.linop import XRayProject, ParallelFixedAxis2dProjector
+from scico.linop.radon_astra import TomographicProjector
+from scico.util import Timer
+
+
+N = 512
+num_angles = 512
+
+det_count = int(jnp.ceil(jnp.sqrt(2 * N**2)))
+
+x_gt = discrete_phantom(Foam(size_range=[0.075, 0.0025], gap=1e-3, porosity=1), size=N)
+x_gt = jax.device_put(x_gt)
+
+angles = jnp.linspace(0, jnp.pi, num=num_angles, endpoint=False)
+
+method_names = ["scico", "astra"]
+timer = Timer(
+    [n + "_init" for n in method_names]
+    + [n + "_first_proj" for n in method_names]
+    + [n + "_avg_proj" for n in method_names]
+)
+
+projectors = {}
+timer.start("scico_init")
+projectors["scico"] = XRayProject(ParallelFixedAxis2dProjector((N, N), angles))
+timer.stop("scico_init")
+
+timer.start("astra_init")
+projectors["astra"] = TomographicProjector(
+    (N, N), detector_spacing=1.0, det_count=det_count, angles=angles
+)
+timer.stop("astra_init")
+
+ys = {}
+for name, H in projectors.items():
+    timer_label = f"{name}_first_proj"
+    timer.start(timer_label)
+    ys[name] = H @ x_gt
+    timer.stop(timer_label)
+
+
+num_repeats = 3
+for name, H in projectors.items():
+    timer_label = f"{name}_avg_proj"
+    timer.start(timer_label)
+    for _ in range(num_repeats):
+        ys[name] = H @ x_gt
+    timer.stop(timer_label)
+    timer.td[timer_label] /= num_repeats
+
+
+print(timer)
+
+"""
+with way 2:
+Label               Accum.       Current
+-------------------------------------------
+astra_avg_proj      7.30e-01 s   Stopped
+astra_first_proj    7.41e-01 s   Stopped
+astra_init          4.63e-03 s   Stopped
+scico_avg_proj      9.96e-01 s   Stopped
+scico_first_proj    9.98e-01 s   Stopped
+scico_init          8.02e+00 s   Stopped
+"""
+
+fig, ax = plt.subplots()
+ax.imshow(ys["scico"])
+fig.show()
+
+fig, ax = plt.subplots()
+ax.imshow(ys["astra"])
+fig.show()

--- a/examples/scripts/index.rst
+++ b/examples/scripts/index.rst
@@ -22,6 +22,7 @@ Computed Tomography
    - ct_astra_modl_train_foam2.py
    - ct_astra_odp_train_foam2.py
    - ct_astra_unet_train_foam2.py
+   - ct_projector_comparison.py
 
 
 Deconvolution

--- a/scico/linop/__init__.py
+++ b/scico/linop/__init__.py
@@ -18,6 +18,7 @@ from ._func import Crop, Pad, Reshape, Slice, Sum, Transpose, linop_from_functio
 from ._linop import ComposedLinearOperator, LinearOperator
 from ._matrix import MatrixOperator
 from ._stack import DiagonalStack, VerticalStack
+from ._xray import XRayProject, ParallelFixedAxis2dProjector
 from ._util import jacobian, operator_norm, power_iteration, valid_adjoint
 
 __all__ = [
@@ -38,6 +39,8 @@ __all__ = [
     "Sum",
     "Transpose",
     "LinearOperator",
+    "XRayProject",
+    "ParallelFixedAxis2dProjector",
     "ComposedLinearOperator",
     "linop_from_function",
     "operator_norm",

--- a/scico/linop/__init__.py
+++ b/scico/linop/__init__.py
@@ -18,8 +18,8 @@ from ._func import Crop, Pad, Reshape, Slice, Sum, Transpose, linop_from_functio
 from ._linop import ComposedLinearOperator, LinearOperator
 from ._matrix import MatrixOperator
 from ._stack import DiagonalStack, VerticalStack
-from ._xray import XRayProject, ParallelFixedAxis2dProjector
 from ._util import jacobian, operator_norm, power_iteration, valid_adjoint
+from ._xray import ParallelFixedAxis2dProjector, XRayProject
 
 __all__ = [
     "CircularConvolve",

--- a/scico/linop/_xray.py
+++ b/scico/linop/_xray.py
@@ -12,6 +12,7 @@ X-ray projector classes.
 from functools import partial
 
 import numpy as np
+
 import jax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
@@ -87,7 +88,7 @@ class ParallelFixedAxis2dProjector:
 
             return inds
 
-        inds = compute_inds(angles)
+        inds = compute_inds(angles)  # (len(angles), *im_shape)
 
         @partial(jax.vmap, in_axes=(None, 0))
         def project_inds(im: ArrayLike, inds: ArrayLike) -> ArrayLike:
@@ -98,38 +99,3 @@ class ParallelFixedAxis2dProjector:
             return project_inds(im, inds)
 
         self.project = project
-
-
-# num_angles = 127
-
-# x = jnp.ones((128, 129))
-
-
-# H = ParallelFixedAxis2dProjector(x.shape, angles)
-# y1 = H.project(x)
-
-# import matplotlib.pyplot as plt
-
-# fig, ax = plt.subplots()
-# ax.imshow(y)
-# fig.show()
-
-# f = lambda x: H.project(x)[65, 90]
-# grad_f = jax.grad(f)
-
-# fig, ax = plt.subplots()
-# ax.imshow(grad_f(x))
-# fig.show()
-
-
-# ## back project
-
-
-# bad_angle = jnp.array([jnp.pi / 4])
-# H = ParallelFixedAxis2dProjector(x.shape, bad_angle)
-# y = H.project(x)
-
-
-# fig, ax = plt.subplots()
-# ax.plot(y[0])
-# fig.show()

--- a/scico/linop/_xray.py
+++ b/scico/linop/_xray.py
@@ -10,6 +10,7 @@
 X-ray projector classes.
 """
 from functools import partial
+from typing import Optional
 
 import numpy as np
 
@@ -29,7 +30,7 @@ class XRayProject(LinearOperator):
     :class:`LinearOperator`.
     """
 
-    def __init__(self, projector: object):
+    def __init__(self, projector):
         r"""
         Args:
             projector: instance of an X-ray projector object to wrap,
@@ -48,7 +49,11 @@ class ParallelFixedAxis2dProjector:
     """Parallel ray, single axis, 2D X-ray projector."""
 
     def __init__(
-        self, im_shape: Shape, angles: ArrayLike, det_length: int = None, do_dithering: bool = True
+        self,
+        im_shape: Shape,
+        angles: ArrayLike,
+        det_length: Optional[int] = None,
+        do_dithering: bool = True,
     ):
         r"""
         Args:

--- a/scico/linop/_xray.py
+++ b/scico/linop/_xray.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020-2023 by SCICO Developers
+# All rights reserved. BSD 3-clause License.
+# This file is part of the SCICO package. Details of the copyright and
+# user license can be found in the 'LICENSE' file distributed with the
+# package.
+
+
+"""
+X-ray projector classes.
+"""
+from functools import partial
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+
+from ._linop import LinearOperator
+
+
+class XRayProject(LinearOperator):
+    """options to select type of projection"""
+
+    def __init__(self, projector):
+        self._eval = projector.project
+
+        super().__init__(
+            input_shape=projector.im_shape,
+            output_shape=(len(projector.angles), *projector.det_shape),
+        )
+
+
+class ParallelFixedAxis2dProjector:
+    """Parallel ray, single axis, 2D X-ray projector"""
+
+    def __init__(self, im_shape, angles, det_length=None, dither=True):
+        self.im_shape = im_shape
+        self.angles = angles
+
+        im_shape = np.array(im_shape)
+
+        x0 = -(im_shape - 1) / 2
+
+        if det_length is None:
+            det_length = int(np.ceil(np.linalg.norm(im_shape)))
+        self.det_shape = (det_length,)
+
+        y0 = -det_length / 2
+
+        @jax.vmap
+        def compute_inds(angle: float) -> ArrayLike:
+            # fast, but does not allow easy dithering
+            # dydx = jnp.stack((jnp.cos(angle), jnp.sin(angle)))
+            # Px0 = jnp.dot(x0, dydx)
+            # Px = (
+            #     Px0
+            #     + dydx[0] * jnp.arange(im_shape[0])[:, jnp.newaxis]
+            #     + dydx[1] * jnp.arange(im_shape[1])[jnp.newaxis, :]
+            # )
+
+            x = jnp.stack(
+                jnp.meshgrid(
+                    *(
+                        jnp.arange(shape_i) * step_i + start_i
+                        for start_i, step_i, shape_i in zip(x0, [1, 1], im_shape)
+                    ),
+                    indexing="ij",
+                ),
+                axis=-1,
+            )
+
+            # dither
+            if dither:
+                key = jax.random.PRNGKey(0)
+                x = x + jax.random.uniform(key, shape=x.shape, minval=-0.5, maxval=0.5)
+
+            # project
+            Px = x[..., 0] * jnp.cos(angle) + x[..., 1] * jnp.sin(angle)
+
+            # quantize
+            inds = jnp.floor((Px - y0)).astype(int)
+
+            # map negative inds to y_size, which is out of bounds and will be ignored
+            # otherwise they index from the end like x[-1]
+            inds = jnp.where(inds < 0, det_length, inds)
+
+            return inds
+
+        inds = compute_inds(angles)
+
+        @partial(jax.vmap, in_axes=(None, 0))
+        def project_inds(im: ArrayLike, inds: ArrayLike) -> ArrayLike:
+            return jnp.zeros(det_length).at[inds].add(im)
+
+        @jax.jit
+        def project(im: ArrayLike) -> ArrayLike:
+            return project_inds(im, inds)
+
+        self.project = project
+
+
+# num_angles = 127
+
+# x = jnp.ones((128, 129))
+
+
+# H = ParallelFixedAxis2dProjector(x.shape, angles)
+# y1 = H.project(x)
+
+# import matplotlib.pyplot as plt
+
+# fig, ax = plt.subplots()
+# ax.imshow(y)
+# fig.show()
+
+# f = lambda x: H.project(x)[65, 90]
+# grad_f = jax.grad(f)
+
+# fig, ax = plt.subplots()
+# ax.imshow(grad_f(x))
+# fig.show()
+
+
+# ## back project
+
+
+# bad_angle = jnp.array([jnp.pi / 4])
+# H = ParallelFixedAxis2dProjector(x.shape, bad_angle)
+# y = H.project(x)
+
+
+# fig, ax = plt.subplots()
+# ax.plot(y[0])
+# fig.show()

--- a/scico/linop/_xray.py
+++ b/scico/linop/_xray.py
@@ -53,7 +53,7 @@ class ParallelFixedAxis2dProjector:
         im_shape: Shape,
         angles: ArrayLike,
         det_length: Optional[int] = None,
-        do_dithering: bool = True,
+        dither: bool = True,
     ):
         r"""
         Args:
@@ -61,7 +61,7 @@ class ParallelFixedAxis2dProjector:
             angles: (num_angles,) array of angles in radians.
             det_length: Length of detector, in ``None``, defaults to the
                 length of diagonal of `im_shape`.
-            do_dither: If ``True`` randomly shift pixel locations to
+            dither: If ``True`` randomly shift pixel locations to
                 reduce projection artifacts caused by aliasing.
         """
         self.im_shape = im_shape
@@ -94,7 +94,7 @@ class ParallelFixedAxis2dProjector:
             )
 
             # dither
-            if do_dithering:
+            if dither:
                 key = jax.random.PRNGKey(0)
                 x = x + jax.random.uniform(key, shape=x.shape, minval=-0.5, maxval=0.5)
 

--- a/scico/test/linop/test_xray.py
+++ b/scico/test/linop/test_xray.py
@@ -22,5 +22,5 @@ def test_apply():
     assert y.shape[1] == det_length
 
     # dither off
-    H = XRayProject(ParallelFixedAxis2dProjector(x.shape, angles, do_dithering=False))
+    H = XRayProject(ParallelFixedAxis2dProjector(x.shape, angles, dither=False))
     y = H @ x

--- a/scico/test/linop/test_xray.py
+++ b/scico/test/linop/test_xray.py
@@ -1,0 +1,26 @@
+import jax.numpy as jnp
+
+from scico.linop import ParallelFixedAxis2dProjector, XRayProject
+
+
+def test_apply():
+    im_shape = (12, 13)
+    num_angles = 10
+    x = jnp.ones(im_shape)
+
+    angles = jnp.linspace(0, jnp.pi, num=num_angles, endpoint=False)
+
+    # general projection
+    H = XRayProject(ParallelFixedAxis2dProjector(x.shape, angles))
+    y = H @ x
+    assert y.shape[0] == (num_angles)
+
+    # fixed det_length
+    det_length = 14
+    H = XRayProject(ParallelFixedAxis2dProjector(x.shape, angles, det_length=det_length))
+    y = H @ x
+    assert y.shape[1] == det_length
+
+    # dither off
+    H = XRayProject(ParallelFixedAxis2dProjector(x.shape, angles, do_dithering=False))
+    y = H @ x

--- a/scico/test/test_ray_tune.py
+++ b/scico/test/test_ray_tune.py
@@ -7,19 +7,18 @@ import pytest
 
 try:
     import ray
-    from scico.ray import report, tune
+    from scico.ray import train, tune
 
     ray.init(num_cpus=1)
 except ImportError as e:
     pytest.skip("ray.tune not installed", allow_module_level=True)
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_random_run():
-    def eval_params(config, reporter):
+    def eval_params(config):
         x, y = config["x"], config["y"]
         cost = x**2 + (y - 0.5) ** 2
-        reporter(cost=cost)
+        train.report({"cost": cost})
 
     config = {"x": tune.uniform(-1, 1), "y": tune.uniform(-1, 1)}
     resources = {"gpu": 0, "cpu": 1}
@@ -40,12 +39,11 @@ def test_random_run():
     assert np.abs(best_config["y"] - 0.5) < 0.25
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_random_tune():
     def eval_params(config):
         x, y = config["x"], config["y"]
         cost = x**2 + (y - 0.5) ** 2
-        report({"cost": cost})
+        train.report({"cost": cost})
 
     config = {"x": tune.uniform(-1, 1), "y": tune.uniform(-1, 1)}
     resources = {"gpu": 0, "cpu": 1}
@@ -66,12 +64,11 @@ def test_random_tune():
     assert np.abs(best_config["y"] - 0.5) < 0.25
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_hyperopt_run():
-    def eval_params(config, reporter):
+    def eval_params(config):
         x, y = config["x"], config["y"]
         cost = x**2 + (y - 0.5) ** 2
-        reporter(cost=cost)
+        train.report({"cost": cost})
 
     config = {"x": tune.uniform(-1, 1), "y": tune.uniform(-1, 1)}
     resources = {"gpu": 0, "cpu": 1}
@@ -90,12 +87,11 @@ def test_hyperopt_run():
     assert np.abs(best_config["y"] - 0.5) < 0.25
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_hyperopt_tune():
     def eval_params(config):
         x, y = config["x"], config["y"]
         cost = x**2 + (y - 0.5) ** 2
-        report({"cost": cost})
+        train.report({"cost": cost})
 
     config = {"x": tune.uniform(-1, 1), "y": tune.uniform(-1, 1)}
     resources = {"gpu": 0, "cpu": 1}
@@ -115,12 +111,11 @@ def test_hyperopt_tune():
     assert np.abs(best_config["y"] - 0.5) < 0.25
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_hyperopt_tune_alt_init():
     def eval_params(config):
         x, y = config["x"], config["y"]
         cost = x**2 + (y - 0.5) ** 2
-        report({"cost": cost})
+        train.report({"cost": cost})
 
     config = {"x": tune.uniform(-1, 1), "y": tune.uniform(-1, 1)}
     tuner = tune.Tuner(

--- a/scico/util.py
+++ b/scico/util.py
@@ -395,7 +395,6 @@ class Timer:
         s += "-" * (lfldln + 25) + "\n"
         # Construct table of timer details
         for lbl in sorted(self.t0):
-            print(lbl)
             td = self.td[lbl]
             if self.t0[lbl] is None:
                 ts = " Stopped"

--- a/scico/util.py
+++ b/scico/util.py
@@ -395,6 +395,7 @@ class Timer:
         s += "-" * (lfldln + 25) + "\n"
         # Construct table of timer details
         for lbl in sorted(self.t0):
+            print(lbl)
             td = self.td[lbl]
             if self.t0[lbl] is None:
                 ts = " Stopped"


### PR DESCRIPTION
For now, it's the simplest (2D, not very configurable) example. Extension to 3D slice-by-slice should be straightforward.

The structure of the code requires input. I designed this so that the projector could easily be cut and pasted outside of SCICO if desired.

Timing versus ASTRA is encouraging, see `ct_projector_comparison.py`.