### PR TITLE
Address deprecation warning in `scico.flax` 

### DIFF
--- a/scico/flax/train/input_pipeline.py
+++ b/scico/flax/train/input_pipeline.py
@@ -26,7 +26,7 @@ from scico.numpy import Array
 from .typed_dict import DataSetDict
 
 DType = Any
-KeyArray = Union[Array, jax.random.PRNGKeyArray]
+KeyArray = Union[Array, jax.Array]
 
 
 class IterateData:

--- a/scico/flax/train/state.py
+++ b/scico/flax/train/state.py
@@ -21,7 +21,7 @@ from scico.typing import Shape
 from .typed_dict import ConfigDict, ModelVarDict
 
 ModuleDef = Any
-KeyArray = Union[Array, jax.random.PRNGKeyArray]
+KeyArray = Union[Array, jax.Array]
 PyTree = Any
 ArrayTree = optax.Params
 

--- a/scico/flax/train/steps.py
+++ b/scico/flax/train/steps.py
@@ -19,7 +19,7 @@ from scico.numpy import Array
 from .state import TrainState
 from .typed_dict import DataSetDict, MetricsDict
 
-KeyArray = Union[Array, jax.random.PRNGKeyArray]
+KeyArray = Union[Array, jax.Array]
 PyTree = Any
 
 

--- a/scico/flax/train/trainer.py
+++ b/scico/flax/train/trainer.py
@@ -47,9 +47,10 @@ from .steps import eval_step, train_step, train_step_post
 from .typed_dict import ConfigDict, DataSetDict, MetricsDict, ModelVarDict
 
 ModuleDef = Any
-KeyArray = Union[Array, jax.random.PRNGKeyArray]
+KeyArray = Union[Array, jax.Array]
 PyTree = Any
 DType = Any
+
 
 # sync across replicas
 def sync_batch_stats(state: TrainState) -> TrainState:


### PR DESCRIPTION
Address `DeprecationWarning: jax.random.KeyArray is deprecated.`