### PR TITLE
Make bm3d and bm4d optional

### DIFF
--- a/.github/workflows/pytest_ubuntu.yml
+++ b/.github/workflows/pytest_ubuntu.yml
@@ -66,6 +66,7 @@ jobs:
           mamba install -c conda-forge pyyaml
           pip install --upgrade --force-reinstall scipy>=1.6.0  # Temporary fix for GLIBCXX_3.4.30 not found in conda forge version
           pip install bm4d>=4.0.0
+          pip install bm4d>=4.2.2
           pip install "ray[tune]>=2.0.0"
           pip install hyperopt
       # Install package to be tested

--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -3,3 +3,5 @@ colour_demosaicing
 xdesign>=0.5.5
 ray[tune]>=2.0.0
 hyperopt
+bm3d>=4.0.0
+bm4d>=4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,5 @@ matplotlib
 jaxlib>=0.4.3,<=0.4.16
 jax>=0.4.3,<=0.4.16
 flax>=0.6.1,<=0.6.9
-bm3d>=4.0.0
-bm4d>=4.2.2
 svmbir>=0.3.3
 pyabel>=0.9.0


### PR DESCRIPTION
Move `bm3d` and `bm4d` to examples requirements.