### PR TITLE
Resolve #468

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,15 +6,15 @@ SCICO Release Notes
 Version 0.0.5   (unreleased)
 ----------------------------
 
-• New functional ``functional.AnisotropicTVNorm`` with proximal operator
-  approximation.
+• New functionals ``functional.AnisotropicTVNorm`` and
+  ``functional.ProximalAverage`` with proximal operator approximations.
 • New integrated Radon/X-ray transform ``linop.XRayTransform``.
 • Rename modules ``radon_astra`` and ``radon_svmbir`` to ``xray.astra`` and
   ``xray.svmbir`` respectively, and rename ``TomographicProjector`` classes
   to ``XRayTransform``.
 • Rename ``AbelProjector`` to ``AbelTransform``.
 • Rename ``solver.ATADSolver`` to ``solver.MatrixATADSolver``.
-• Support ``jaxlib`` and ``jax`` versions 0.4.3 to 0.4.19.
+• Support ``jaxlib`` and ``jax`` versions 0.4.3 to 0.4.20.
 
 
 

--- a/scico/functional/_functional.py
+++ b/scico/functional/_functional.py
@@ -173,10 +173,10 @@ class ScaledFunctional(Functional):
         proximal operator of the unscaled functional with the proximal
         operator scaling consisting of the product of the two scaling
         factors, i.e., for functional :math:`f` and scaling factors
-        :math:`\alpha` and :math:`\beta`, the proximal operator with scaling
-        parameter :math:`\alpha` of scaled functional :math:`\beta f` is
-        the proximal operator with scaling parameter :math:`\alpha \beta`
-        of functional :math:`f`,
+        :math:`\alpha` and :math:`\beta`, the proximal operator with
+        scaling parameter :math:`\alpha` of scaled functional
+        :math:`\beta f` is the proximal operator with scaling parameter
+        :math:`\alpha \beta` of functional :math:`f`,
 
         .. math::
            \prox_{\alpha (\beta f)}(\mb{v}) =

--- a/scico/functional/_functional.py
+++ b/scico/functional/_functional.py
@@ -183,7 +183,7 @@ class ScaledFunctional(Functional):
            \prox_{(\alpha \beta) f}(\mb{v}) \;.
 
         """
-        return self.functional.prox(v, lam * self.scale)
+        return self.functional.prox(v, lam * self.scale, **kwargs)
 
 
 class SeparableFunctional(Functional):
@@ -245,7 +245,9 @@ class SeparableFunctional(Functional):
 
         """
         if len(v.shape) == len(self.functional_list):
-            return snp.blockarray([fi.prox(vi, lam) for fi, vi in zip(self.functional_list, v)])
+            return snp.blockarray(
+                [fi.prox(vi, lam, **kwargs) for fi, vi in zip(self.functional_list, v)]
+            )
         raise ValueError(
             f"Number of blocks in v, {len(v.shape)}, and length of functional_list, "
             f"{len(self.functional_list)}, do not match."

--- a/scico/functional/_functional.py
+++ b/scico/functional/_functional.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from typing import List, Optional, Union
 
-import jax
-
 import scico
 from scico import numpy as snp
 from scico.numpy import Array, BlockArray
@@ -44,7 +42,7 @@ class Functional:
         return f"""{type(self)} (has_eval = {self.has_eval}, has_prox = {self.has_prox})"""
 
     def __mul__(self, other: Union[float, int]) -> ScaledFunctional:
-        if snp.isscalar(other) or isinstance(other, jax.core.Tracer):
+        if snp.util.is_scalar_equiv(other):
             return ScaledFunctional(self, other)
         return NotImplemented
 
@@ -146,7 +144,7 @@ class ScaledFunctional(Functional):
         return self.scale * self.functional(x)
 
     def __mul__(self, other: Union[float, int]) -> ScaledFunctional:
-        if snp.isscalar(other) or isinstance(other, jax.core.Tracer):
+        if snp.util.is_scalar_equiv(other):
             return ScaledFunctional(self.functional, other * self.scale)
         return NotImplemented
 

--- a/scico/loss.py
+++ b/scico/loss.py
@@ -219,12 +219,9 @@ class SquaredL2Loss(Loss):
             ATWA = c * A.conj() * W * A  # type: ignore
             return lhs / (ATWA + 1.0)
 
-        #   prox_{f}(v) = arg min  1/2 || v - x ||_2^2 + λ 𝛼 || A x - y ||^2_W
-        #                    x
-        # solution at:
-        #
-        #   (I + λ 2𝛼 A^T W A) x = v + λ 2𝛼 A^T W y
-        #
+        #   prox_f(v) = arg min  1/2 || v - x ||_2^2 + λ 𝛼 || A x - y ||^2_W
+        #                  x
+        #   with solution: (I + λ 2𝛼 A^T W A) x = v + λ 2𝛼 A^T W y
         W = self.W
         A = self.A
         𝛼 = self.scale

--- a/scico/loss.py
+++ b/scico/loss.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Union
 
 import jax
 
+import scico
 import scico.numpy as snp
 from scico import functional, linop, operator
 from scico.numpy import Array, BlockArray
@@ -125,6 +126,7 @@ class Loss(functional.Functional):
     @_loss_mul_div_wrapper
     def __mul__(self, other):
         new_loss = copy(self)
+        new_loss._grad = scico.grad(new_loss.__call__)
         new_loss.set_scale(self.scale * other)
         return new_loss
 
@@ -134,6 +136,7 @@ class Loss(functional.Functional):
     @_loss_mul_div_wrapper
     def __truediv__(self, other):
         new_loss = copy(self)
+        new_loss._grad = scico.grad(new_loss.__call__)
         new_loss.set_scale(self.scale / other)
         return new_loss
 

--- a/scico/test/functional/test_loss.py
+++ b/scico/test/functional/test_loss.py
@@ -84,6 +84,16 @@ class TestLoss:
         pf = prox_test(self.v, L_d, L_d.prox, 0.75)
         pf = prox_test(self.v, L, L.prox, 0.75)
 
+    def test_squared_l2_grad(self):
+        La = loss.SquaredL2Loss(y=self.y)
+        Lb = loss.SquaredL2Loss(y=self.y, scale=5e0)
+        Lc = 1e1 * La
+        ga = La.grad(self.v)
+        gb = Lb.grad(self.v)
+        gc = Lc.grad(self.v)
+        np.testing.assert_allclose(1e1 * ga, gb)
+        np.testing.assert_allclose(gb, gc)
+
     def test_weighted_squared_l2(self):
         L = loss.SquaredL2Loss(y=self.y, A=self.Ao, W=self.W)
         assert L.has_eval
@@ -119,7 +129,6 @@ class TestLoss:
 
 
 class TestAbsLoss:
-
     abs_loss = (
         (loss.SquaredL2AbsLoss, snp.abs),
         (loss.SquaredL2SquaredAbsLoss, lambda x: snp.abs(x) ** 2),
@@ -218,7 +227,7 @@ def test_cubic_root():
     r = loss._dep_cubic_root(p, q)
     err = snp.abs(r**3 + p * r + q)
     assert err.max() < 2e-4
-    # Test
+    # Test loss of precision warning
     p = snp.array(1e-4, dtype=snp.float32)
     q = snp.array(1e1, dtype=snp.float32)
     with pytest.warns(UserWarning):

--- a/scico/test/functional/test_misc.py
+++ b/scico/test/functional/test_misc.py
@@ -130,3 +130,15 @@ def test_l21norm(axis):
     prxana = (l2ana - 1.0) / l2ana * x
     prxnum = F.prox(x, 1.0)
     np.testing.assert_allclose(prxana, prxnum, rtol=1e-5)
+
+
+def test_scalar_aggregation():
+    f = functional.L2Norm()
+    g = 2.0 * f
+    h = 5.0 * g
+    assert isinstance(g, functional.ScaledFunctional)
+    assert isinstance(g.functional, functional.L2Norm)
+    assert g.scale == 2.0
+    assert isinstance(h, functional.ScaledFunctional)
+    assert isinstance(h.functional, functional.L2Norm)
+    assert h.scale == 10.0


### PR DESCRIPTION
Resolve #468.

Also:
* Improve scaling of `ScaledFunctional`, so that e.g. ` 5.0 * (2.0 * functional.L2Norm())` is a `ScaledFunctional` with a scale of 10 of an `L2Norm` rather than a `ScaledFunctional` with a scale of 5 of a `ScaledFunctional`.
* Some cleaning up and code re-organization.
* Update change summary `CHANGES.rst`.