### PR TITLE
Fix fractional centers in CircularConvolve

### DIFF
--- a/scico/linop/_circconv.py
+++ b/scico/linop/_circconv.py
@@ -140,8 +140,7 @@ class CircularConvolve(LinearOperator):
                 shifts: Tuple[np.ndarray, ...] = np.ix_(
                     *tuple(
                         np.select(
-                            #  see "Closed Form Variable Fractional Time Delay Using FFT" or
-                            #  "Comments on 'Sinc Interpolation of Discrete Periodic Signals'"
+                            # see doi:10.1109/78.700979 and doi:10.1109/LSP.2012.2191280
                             [np.arange(s) < s / 2, np.arange(s) == s / 2, np.arange(s) > s / 2],
                             [
                                 np.exp(-1j * k * 2 * np.pi * np.arange(s) / s),

--- a/scico/test/linop/test_circconv.py
+++ b/scico/test/linop/test_circconv.py
@@ -160,10 +160,11 @@ class TestCircularConvolve:
 
     def test_fractional_center(self):
         """A fractional center should keep outputs real"""
-        x, _ = uniform(minval=-1, maxval=1, shape=(3, 4), key=self.key)
+        x, _ = uniform(minval=-1, maxval=1, shape=(4, 5), key=self.key)
         h, _ = uniform(minval=-1, maxval=1, shape=(2, 2), key=self.key)
         A = CircularConvolve(h=h, input_shape=x.shape, h_center=[0.1, 2.7])
 
+        # taken from CircularConvolve._eval
         x_dft = snp.fft.fftn(x, axes=A.x_fft_axes)
         hx = snp.fft.ifftn(
             A.h_dft * x_dft,

--- a/scico/test/linop/test_circconv.py
+++ b/scico/test/linop/test_circconv.py
@@ -159,9 +159,9 @@ class TestCircularConvolve:
         np.testing.assert_allclose(A @ x, snp.roll(B @ x, shift), atol=1e-5)
 
     def test_fractional_center(self):
-        """A fractional center should keep outputs real"""
-        x, _ = uniform(minval=-1, maxval=1, shape=(4, 5), key=self.key)
-        h, _ = uniform(minval=-1, maxval=1, shape=(2, 2), key=self.key)
+        """A fractional center should keep outputs real."""
+        x, key = uniform(minval=-1, maxval=1, shape=(4, 5), key=self.key)
+        h, _ = uniform(minval=-1, maxval=1, shape=(2, 2), key=key)
         A = CircularConvolve(h=h, input_shape=x.shape, h_center=[0.1, 2.7])
 
         # taken from CircularConvolve._eval

--- a/scico/test/linop/test_circconv.py
+++ b/scico/test/linop/test_circconv.py
@@ -33,7 +33,6 @@ class TestCircularConvolve:
     @pytest.mark.parametrize("input_dtype", [np.float32, np.complex64])
     @pytest.mark.parametrize("axes_shape_spec", SHAPE_SPECS)
     def test_eval(self, axes_shape_spec, input_dtype, jit):
-
         x_shape, ndims, h_shape = axes_shape_spec
 
         h, key = randn(tuple(h_shape), dtype=input_dtype, key=self.key)
@@ -62,7 +61,6 @@ class TestCircularConvolve:
     @pytest.mark.parametrize("input_dtype", [np.float32, np.complex64])
     @pytest.mark.parametrize("axes_shape_spec", SHAPE_SPECS)
     def test_adjoint(self, axes_shape_spec, input_dtype, jit):
-
         x_shape, ndims, h_shape = axes_shape_spec
 
         h, key = randn(tuple(h_shape), dtype=input_dtype, key=self.key)
@@ -159,6 +157,20 @@ class TestCircularConvolve:
         else:
             shift = -center[0]
         np.testing.assert_allclose(A @ x, snp.roll(B @ x, shift), atol=1e-5)
+
+    def test_fractional_center(self):
+        """A fractional center should keep outputs real"""
+        x, _ = uniform(minval=-1, maxval=1, shape=(3, 4), key=self.key)
+        h, _ = uniform(minval=-1, maxval=1, shape=(2, 2), key=self.key)
+        A = CircularConvolve(h=h, input_shape=x.shape, h_center=[0.1, 2.7])
+
+        x_dft = snp.fft.fftn(x, axes=A.x_fft_axes)
+        hx = snp.fft.ifftn(
+            A.h_dft * x_dft,
+            axes=A.ifft_axes,
+        )
+
+        np.testing.assert_allclose(hx, snp.real(hx))
 
     @pytest.mark.parametrize("axes_shape_spec", SHAPE_SPECS)
     @pytest.mark.parametrize("input_dtype", [np.float32, np.complex64])


### PR DESCRIPTION
Using a fractional filter center for a `CircularConvolve` operator currently gives nonsense results. This PR adds a test for this nonsense (checking that the imaginary part of the result of filtering is small) and changes the way centers are handled to fix the problem. Relevant references:

F. Candocia and J. C. Principe, "Comments on "Sinc interpolation of discrete periodic signals," in IEEE Transactions on Signal Processing, vol. 46, no. 7, pp. 2044-2047, July 1998, doi: 10.1109/78.700979.

"S. -C. Pei and Y. -C. Lai, "Closed Form Variable Fractional Time Delay Using FFT," in IEEE Signal Processing Letters, vol. 19, no. 5, pp. 299-302, May 2012, doi: 10.1109/LSP.2012.2191280.

