### PR TITLE
Add support for `np.newaxis` to indexing syntax supported by `linop.Slice`

### DIFF
--- a/scico/test/linop/test_func.py
+++ b/scico/test/linop/test_func.py
@@ -91,6 +91,8 @@ slice_examples = [
     np.s_[1:, :-3],
     np.s_[1:, :, :3],
     np.s_[1:, ..., 2:],
+    np.s_[np.newaxis],
+    np.s_[:, np.newaxis],
 ]
 
 

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -99,6 +99,10 @@ def test_slice_length_other(length, slc):
         np.s_[..., 2:],
         np.s_[..., 2:, :],
         np.s_[1:, ..., 2:],
+        np.s_[np.newaxis],
+        np.s_[:, np.newaxis],
+        np.s_[np.newaxis, :, np.newaxis],
+        np.s_[np.newaxis, ..., 0:2, :],
     ),
 )
 def test_indexed_shape(shape, slc):


### PR DESCRIPTION
Add support for `np.newaxis` to indexing syntax supported by `linop.Slice`.