### PR TITLE
Improve `TVNorm` implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,13 @@ Version 0.0.6   (unreleased)
 ----------------------------
 
 • Significant changes to ``linop.xray.astra`` API.
-• New functional ``functional.IsotropicTVNorm``.
+• New functional ``functional.IsotropicTVNorm`` and faster implementation
+  of ``functional.AnisotropicTVNorm``.
 • Rename ``scico.flax.save_weights`` and ``scico.flax.load_weights`` to
   ``scico.flax.save_variables`` and ``scico.flax.load_variables``
   respectively.
+• Support ``jaxlib`` and ``jax`` versions 0.4.3 to 0.4.28.
+• Support ``flax`` versions between 0.8.0 and 0.8.3 (inclusive).
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Version 0.0.6   (unreleased)
 • Significant changes to ``linop.xray.astra`` API.
 • New functional ``functional.IsotropicTVNorm`` and faster implementation
   of ``functional.AnisotropicTVNorm``.
+• Rename ``scico.numpy.util.parse_axes`` to
+  ``scico.numpy.util.normalize_axes``.
 • Rename ``scico.flax.save_weights`` and ``scico.flax.load_weights`` to
   ``scico.flax.save_variables`` and ``scico.flax.load_variables``
   respectively.
@@ -40,8 +42,8 @@ Version 0.0.5   (2023-12-18)
 Version 0.0.4   (2023-08-03)
 ----------------------------
 
-• Add new ``Function`` class for representing array-to-array mappings with more
-  than one input.
+• Add new ``Function`` class for representing array-to-array mappings with
+  more than one input.
 • Add new methods and a function for computing Jacobian-vector products for
   ``Operator`` objects.
 • Add new proximal ADMM solvers.

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -286,7 +286,7 @@ class IsotropicTVNorm(TVNorm):
 class SingleAxisFiniteSum(LinearOperator):
     r"""Two-point sum operator acting along a single axis.
 
-    Boundary handling is circular,  so that the sum operator corresponds
+    Boundary handling is circular, so that the sum operator corresponds
     to the matrix
 
     .. math::
@@ -314,7 +314,7 @@ class SingleAxisFiniteSum(LinearOperator):
             input_shape: Shape of input array.
             input_dtype: `dtype` for input argument. Defaults to
                 :attr:`~numpy.float32`.
-            axis: Axis over which to apply finite sum operator.
+            axis: Axis over which to apply sum operator.
             jit: If ``True``, jit the evaluation, adjoint, and gram
                 functions of the :class:`LinearOperator`.
         """
@@ -348,8 +348,7 @@ class FiniteSum(VerticalStack):
     """Two-point sum operator.
 
     Compute two-point sums along the specified axes, returning the
-    results in a :class:`jax.Array` (when possible) or :class:`BlockArray`.
-    See :class:`VerticalStack` for details on how this choice is made.
+    results stacked on axis 0 of a :class:`jax.Array`.
     See :class:`SingleAxisFiniteSum` for boundary handling details.
     """
 
@@ -391,7 +390,7 @@ class SingleAxisHaarTransform(VerticalStack):
     Compute one level of a shift-invariant Haar transform along the
     specified axis, returning the results in a :class:`jax.Array`
     consisting of sum and difference components (corresponding to lowpass
-    and highpass filtered components respectively) on axis 0.
+    and highpass filtered components respectively) stacked on axis 0.
     See :class:`SingleAxisFiniteSum` for boundary handling details.
     """
 

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -151,16 +151,12 @@ class TVNorm(Functional):
             self.WP, self.CWT = self._prox_operators(v.shape, v.dtype, self.axes)
 
         if self.circular:
-            slce = snp.s_[1]
+            slce = snp.s_[:, 1]
         else:
             slce = (
-                (
-                    1,
-                    snp.s_[:],
-                )
-                + (snp.s_[:],) * (v.ndim - ndims)
-                + (snp.s_[:-1],) * ndims
-            )
+                snp.s_[:],
+                snp.s_[1],
+            ) + tuple([snp.s_[:-1] if i in axes else snp.s_[:] for i, s in enumerate(input_shape)])
         # Apply shrinkage to highpass component of shift-invariant Haar transform
         # of padded input (or to non-boundary region thereof for non-circular
         # boundary conditions).

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -156,7 +156,7 @@ class TVNorm(Functional):
             slce = (
                 snp.s_[:],
                 snp.s_[1],
-            ) + tuple([snp.s_[:-1] if i in axes else snp.s_[:] for i, s in enumerate(input_shape)])
+            ) + tuple([snp.s_[:-1] if i in axes else snp.s_[:] for i, s in enumerate(v.shape)])
         # Apply shrinkage to highpass component of shift-invariant Haar transform
         # of padded input (or to non-boundary region thereof for non-circular
         # boundary conditions).

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -106,15 +106,6 @@ class TVNorm(Functional):
             self.G = self._call_operator(x.shape, x.dtype, self.axes)
         return self.norm(self.G @ x)
 
-    @staticmethod
-    def _shape(idx: int, ndims: int) -> Tuple:
-        """Construct a shape tuple.
-
-        Construct a tuple of size `ndims` with all unit entries except
-        for index `idx`, which has a -1 entry.
-        """
-        return (1,) * idx + (-1,) + (1,) * (ndims - idx - 1)
-
     def _prox_operators(
         self, input_shape: Shape, input_dtype: DType, axes: Optional[Axes]
     ) -> Tuple[LinearOperator, LinearOperator]:

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -413,10 +413,10 @@ class SingleAxisHaarTransform(VerticalStack):
                 functions of the :class:`LinearOperator`.
         """
         self.axis = axis
-        self.HaarL = (1.0 / 2.0) * SingleAxisFiniteSum(
+        self.HaarL = (1.0 / snp.sqrt(2.0)) * SingleAxisFiniteSum(
             input_shape, input_dtype=input_dtype, axis=axis, jit=jit, **kwargs
         )
-        self.HaarH = (1.0 / 2.0) * SingleAxisFiniteDifference(
+        self.HaarH = (1.0 / snp.sqrt(2.0)) * SingleAxisFiniteDifference(
             input_shape, input_dtype=input_dtype, axis=axis, circular=True, jit=jit, **kwargs
         )
         super().__init__(

--- a/scico/functional/_tvnorm.py
+++ b/scico/functional/_tvnorm.py
@@ -23,7 +23,7 @@ from scico.linop import (
     linop_over_axes,
 )
 from scico.numpy import Array
-from scico.numpy.util import parse_axes
+from scico.numpy.util import normalize_axes
 from scico.typing import Axes, DType, Shape
 
 from ._functional import Functional
@@ -118,7 +118,7 @@ class TVNorm(Functional):
         self, input_shape: Shape, input_dtype: DType
     ) -> Tuple[LinearOperator, LinearOperator, int, Tuple]:
         """Construct operators required by prox method."""
-        axes = parse_axes(self.axes, input_shape)
+        axes = normalize_axes(self.axes, input_shape)
         ndims = len(axes)
         w_input_shape = (
             # circular boundary: shape of input array

--- a/scico/linop/__init__.py
+++ b/scico/linop/__init__.py
@@ -17,7 +17,7 @@ from ._diff import FiniteDifference, SingleAxisFiniteDifference
 from ._func import Crop, Pad, Reshape, Slice, Sum, Transpose, linop_from_function
 from ._linop import ComposedLinearOperator, LinearOperator
 from ._matrix import MatrixOperator
-from ._stack import DiagonalStack, VerticalStack
+from ._stack import DiagonalStack, VerticalStack, linop_over_axes
 from ._util import jacobian, operator_norm, power_iteration, valid_adjoint
 from .xray import Parallel2dProjector, XRayTransform
 
@@ -44,6 +44,7 @@ __all__ = [
     "Parallel2dProjector",
     "ComposedLinearOperator",
     "linop_from_function",
+    "linop_over_axes",
     "operator_norm",
     "power_iteration",
     "valid_adjoint",

--- a/scico/linop/_diff.py
+++ b/scico/linop/_diff.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2023 by SCICO Developers
+# Copyright (C) 2020-2024 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -17,11 +17,10 @@ from typing import Literal, Optional, Union
 import numpy as np
 
 import scico.numpy as snp
-from scico.numpy.util import parse_axes
 from scico.typing import Axes, DType, Shape
 
 from ._linop import LinearOperator
-from ._stack import VerticalStack
+from ._stack import VerticalStack, linop_over_axes
 
 
 class FiniteDifference(VerticalStack):
@@ -81,22 +80,16 @@ class FiniteDifference(VerticalStack):
             jit: If ``True``, jit the evaluation, adjoint, and gram
                 functions of the :class:`LinearOperator`.
         """
-
-        if axes is None:
-            axes_list = tuple(range(len(input_shape)))
-        elif isinstance(axes, (list, tuple)):
-            axes_list = axes  # type: ignore
-        else:
-            axes_list = (axes,)
-        self.axes = parse_axes(axes_list, input_shape)
-        single_kwargs = dict(
-            input_dtype=input_dtype, prepend=prepend, append=append, circular=circular, jit=False
+        self.axes, ops = linop_over_axes(
+            SingleAxisFiniteDifference,
+            input_shape,
+            axes=axes,
+            input_dtype=input_dtype,
+            prepend=prepend,
+            append=append,
+            circular=circular,
+            jit=False,
         )
-        ops = [
-            SingleAxisFiniteDifference(input_shape, axis=axis, **single_kwargs)  # type: ignore
-            for axis in axes_list
-        ]
-
         super().__init__(
             ops,  # type: ignore
             jit=jit,

--- a/scico/linop/_diff.py
+++ b/scico/linop/_diff.py
@@ -26,7 +26,7 @@ from ._stack import VerticalStack, linop_over_axes
 class FiniteDifference(VerticalStack):
     """Finite difference operator.
 
-    Computes finite differences along the specified axes, returning the
+    Compute finite differences along the specified axes, returning the
     results in a :class:`jax.Array` (when possible) or :class:`BlockArray`.
     See :class:`VerticalStack` for details on how this choice is made.
     See :class:`SingleAxisFiniteDifference` for the mathematical

--- a/scico/linop/_stack.py
+++ b/scico/linop/_stack.py
@@ -13,7 +13,7 @@ from typing import Any, List, Optional, Sequence, Union
 
 import scico.numpy as snp
 from scico.numpy import Array, BlockArray
-from scico.numpy.util import parse_axes
+from scico.numpy.util import normalize_axes
 from scico.operator._stack import DiagonalStack as DStack
 from scico.operator._stack import VerticalStack as VStack
 from scico.typing import Axes, Shape
@@ -175,5 +175,5 @@ def linop_over_axes(
         to construct that list of list of :class:`LinearOperator`, and
         `ops` is the list itself.
     """
-    axes = parse_axes(axes, input_shape)
+    axes = normalize_axes(axes, input_shape)
     return axes, [linop(input_shape, *args, axis=axis, **kwargs) for axis in axes]  # type: ignore

--- a/scico/linop/_stack.py
+++ b/scico/linop/_stack.py
@@ -175,15 +175,5 @@ def linop_over_axes(
         to construct that list of list of :class:`LinearOperator`, and
         `ops` is the list itself.
     """
-    if axes is None:
-        axes = tuple(range(len(input_shape)))
-    elif not isinstance(axes, (list, tuple)):
-        axes = (axes,)
-    if axes is None:
-        axis_list = tuple(range(len(input_shape)))
-    elif isinstance(axes, (list, tuple)):
-        axis_list = axes  # type: ignore
-    else:
-        axis_list = (axes,)
     axes = parse_axes(axes, input_shape)
     return axes, [linop(input_shape, *args, axis=axis, **kwargs) for axis in axes]  # type: ignore

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -25,11 +25,11 @@ from ._blockarray import BlockArray
 
 def parse_axes(
     axes: Axes, shape: Optional[Shape] = None, default: Optional[List[int]] = None
-) -> List[int]:
-    """Normalize `axes` to a list and optionally ensure correctness.
+) -> Sequence[int]:
+    """Normalize `axes` to a sequence and optionally ensure correctness.
 
-    Normalize `axes` to a list and (optionally) ensure that entries refer
-    to axes that exist in `shape`.
+    Normalize `axes` to a tupe or list and (optionally) ensure that
+    entries refer to axes that exist in `shape`.
 
     Args:
         axes: User specification of one or more axes: int, list, tuple,
@@ -38,10 +38,12 @@ def parse_axes(
            If not ``None``, `axes` is checked to make sure its entries
            refer to axes that exist in `shape`.
         default: Default value to return if `axes` is ``None``. By
-           default, `list(range(len(shape)))`.
+           default, `tuple(range(len(shape)))`.
 
     Returns:
-        List of axes (never an int, never ``None``).
+        Tuple or list of axes (never an int, never ``None``). The output
+        will only be a list if the input is a list or if the input is
+        ``None`` and `defaults` is a list.
     """
 
     if axes is None:
@@ -50,7 +52,7 @@ def parse_axes(
                 raise ValueError(
                     "Parameter axes cannot be None without a default or shape specified."
                 )
-            axes = list(range(len(shape)))
+            axes = tuple(range(len(shape)))
         else:
             axes = default
     elif isinstance(axes, (list, tuple)):

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -24,7 +24,10 @@ from ._blockarray import BlockArray
 
 
 def parse_axes(
-    axes: Axes, shape: Optional[Shape] = None, default: Optional[List[int]] = None
+    axes: Axes,
+    shape: Optional[Shape] = None,
+    default: Optional[List[int]] = None,
+    sort: bool = False,
 ) -> Sequence[int]:
     """Normalize `axes` to a sequence and optionally ensure correctness.
 
@@ -33,12 +36,14 @@ def parse_axes(
 
     Args:
         axes: User specification of one or more axes: int, list, tuple,
-           or ``None``.
+           or ``None``. Negative values count from the last to the first
+           axis.
         shape: The shape of the array of which axes are being specified.
            If not ``None``, `axes` is checked to make sure its entries
            refer to axes that exist in `shape`.
         default: Default value to return if `axes` is ``None``. By
            default, `tuple(range(len(shape)))`.
+        sort: If ``True``, sort the returned axis indices.
 
     Returns:
         Tuple or list of axes (never an int, never ``None``). The output
@@ -61,12 +66,17 @@ def parse_axes(
         axes = (axes,)
     else:
         raise ValueError(f"Could not understand axes {axes} as a list of axes.")
-    if shape is not None and max(axes) >= len(shape):
-        raise ValueError(
-            f"Invalid axes {axes} specified; each axis must be less than `len(shape)`={len(shape)}."
-        )
+    if shape is not None:
+        if min(axes) < 0:
+            axes = tuple([len(shape) + a if a < 0 else a for a in axes])
+        if max(axes) >= len(shape):
+            raise ValueError(
+                f"Invalid axes {axes} specified; each axis must be less than `len(shape)`={len(shape)}."
+            )
     if len(set(axes)) != len(axes):
         raise ValueError(f"Duplicate value in axes {axes}; each axis must be unique.")
+    if sort:
+        axes = tuple(sorted(axes))
     return axes
 
 

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -28,7 +28,7 @@ def parse_axes(
 ) -> Sequence[int]:
     """Normalize `axes` to a sequence and optionally ensure correctness.
 
-    Normalize `axes` to a tupe or list and (optionally) ensure that
+    Normalize `axes` to a tuple or list and (optionally) ensure that
     entries refer to axes that exist in `shape`.
 
     Args:

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -23,7 +23,7 @@ from scico.typing import ArrayIndex, Axes, AxisIndex, BlockShape, DType, Shape
 from ._blockarray import BlockArray
 
 
-def parse_axes(
+def normalize_axes(
     axes: Axes,
     shape: Optional[Shape] = None,
     default: Optional[List[int]] = None,

--- a/scico/test/functional/test_tvnorm.py
+++ b/scico/test/functional/test_tvnorm.py
@@ -5,8 +5,22 @@ import pytest
 import scico.random
 from scico import functional, linop, loss, metric
 from scico.examples import create_circular_phantom
+from scico.functional._tvnorm import HaarTransform, SingleAxisHaarTransform
 from scico.optimize.admm import ADMM, LinearSubproblemSolver
 from scico.optimize.pgm import AcceleratedPGM
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_single_axis_haar_transform(axis):
+    x, key = scico.random.randn((3, 4), seed=1234)
+    HT = SingleAxisHaarTransform(x.shape, axis=axis)
+    np.testing.assert_allclose(x, HT.T(HT(x)), rtol=1e-6)
+
+
+def test_haar_transform():
+    x, key = scico.random.randn((3, 4), seed=1234)
+    HT = HaarTransform(x.shape)
+    np.testing.assert_allclose(2 * x, HT.T(HT(x)), rtol=1e-6)
 
 
 @pytest.mark.parametrize("circular", [True, False])

--- a/scico/test/functional/test_tvnorm.py
+++ b/scico/test/functional/test_tvnorm.py
@@ -162,9 +162,11 @@ class Test3D:
         x_tvdn = solver.solve()
 
         if tvtype == "aniso":
-            h = λ * functional.AnisotropicTVNorm(circular=circular, ndims=2, input_shape=y.shape)
+            h = λ * functional.AnisotropicTVNorm(
+                circular=circular, axes=(1, 2), input_shape=y.shape
+            )
         else:
-            h = λ * functional.IsotropicTVNorm(circular=circular, ndims=2, input_shape=y.shape)
+            h = λ * functional.IsotropicTVNorm(circular=circular, axes=(1, 2), input_shape=y.shape)
 
         solver = AcceleratedPGM(
             f=f,

--- a/scico/test/functional/test_tvnorm.py
+++ b/scico/test/functional/test_tvnorm.py
@@ -14,13 +14,13 @@ from scico.optimize.pgm import AcceleratedPGM
 def test_single_axis_haar_transform(axis):
     x, key = scico.random.randn((3, 4), seed=1234)
     HT = SingleAxisHaarTransform(x.shape, axis=axis)
-    np.testing.assert_allclose(x, HT.T(HT(x)), rtol=1e-6)
+    np.testing.assert_allclose(2 * x, HT.T(HT(x)), rtol=1e-6)
 
 
 def test_haar_transform():
     x, key = scico.random.randn((3, 4), seed=1234)
     HT = HaarTransform(x.shape)
-    np.testing.assert_allclose(2 * x, HT.T(HT(x)), rtol=1e-6)
+    np.testing.assert_allclose(4 * x, HT.T(HT(x)), rtol=1e-6)
 
 
 @pytest.mark.parametrize("circular", [True, False])

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -47,7 +47,7 @@ def test_parse_axes():
     np.testing.assert_raises(ValueError, parse_axes, axes)
 
     axes = None
-    assert parse_axes(axes, np.shape([[1, 1], [1, 1]])) == [0, 1]
+    assert parse_axes(axes, np.shape([[1, 1], [1, 1]])) == (0, 1)
 
     axes = None
     assert parse_axes(axes, np.shape([[1, 1], [1, 1]]), default=[0]) == [0]

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -58,6 +58,12 @@ def test_parse_axes():
     axes = 1
     assert parse_axes(axes) == (1,)
 
+    axes = (-1,)
+    assert parse_axes(axes, shape=(1, 2)) == (1,)
+
+    axes = (0, 2, 1)
+    assert parse_axes(axes, shape=(2, 3, 4), sort=True) == (0, 1, 2)
+
     axes = "axes"
     np.testing.assert_raises(ValueError, parse_axes, axes)
 

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -11,7 +11,7 @@ from scico.numpy.util import (
     is_real_dtype,
     is_scalar_equiv,
     no_nan_divide,
-    parse_axes,
+    normalize_axes,
     real_dtype,
     slice_length,
 )
@@ -42,36 +42,36 @@ def test_no_nan_divide_blockarray():
     np.testing.assert_allclose(res[0], x[0] / y[0])
 
 
-def test_parse_axes():
+def test_normalize_axes():
     axes = None
-    np.testing.assert_raises(ValueError, parse_axes, axes)
+    np.testing.assert_raises(ValueError, normalize_axes, axes)
 
     axes = None
-    assert parse_axes(axes, np.shape([[1, 1], [1, 1]])) == (0, 1)
+    assert normalize_axes(axes, np.shape([[1, 1], [1, 1]])) == (0, 1)
 
     axes = None
-    assert parse_axes(axes, np.shape([[1, 1], [1, 1]]), default=[0]) == [0]
+    assert normalize_axes(axes, np.shape([[1, 1], [1, 1]]), default=[0]) == [0]
 
     axes = [1, 2]
-    assert parse_axes(axes) == axes
+    assert normalize_axes(axes) == axes
 
     axes = 1
-    assert parse_axes(axes) == (1,)
+    assert normalize_axes(axes) == (1,)
 
     axes = (-1,)
-    assert parse_axes(axes, shape=(1, 2)) == (1,)
+    assert normalize_axes(axes, shape=(1, 2)) == (1,)
 
     axes = (0, 2, 1)
-    assert parse_axes(axes, shape=(2, 3, 4), sort=True) == (0, 1, 2)
+    assert normalize_axes(axes, shape=(2, 3, 4), sort=True) == (0, 1, 2)
 
     axes = "axes"
-    np.testing.assert_raises(ValueError, parse_axes, axes)
+    np.testing.assert_raises(ValueError, normalize_axes, axes)
 
     axes = 2
-    np.testing.assert_raises(ValueError, parse_axes, axes, np.shape([1]))
+    np.testing.assert_raises(ValueError, normalize_axes, axes, np.shape([1]))
 
     axes = (1, 2, 2)
-    np.testing.assert_raises(ValueError, parse_axes, axes)
+    np.testing.assert_raises(ValueError, normalize_axes, axes)
 
 
 @pytest.mark.parametrize("length", (4, 5, 8, 16, 17))

--- a/scico/typing.py
+++ b/scico/typing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2021-2023 by SCICO Developers
+# Copyright (C) 2021-2024 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SPORCO package. Details of the copyright
 # and user license can be found in the 'LICENSE.txt' file distributed
@@ -7,7 +7,7 @@
 
 """Type definitions."""
 
-from typing import Any, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 try:
     # available in python 3.10
@@ -48,7 +48,7 @@ Shape: TypeAlias = Tuple[int, ...]
 BlockShape: TypeAlias = Tuple[Tuple[int, ...], ...]
 """A shape of a :class:`.BlockArray`."""
 
-Axes: TypeAlias = Union[int, Tuple[int, ...]]
+Axes: TypeAlias = Union[int, Tuple[int, ...], List[int]]
 """Specification of one or more array axes."""
 
 AxisIndex: TypeAlias = Union[slice, EllipsisType, int]


### PR DESCRIPTION
Improve the implementation of `scico.functional.TVNorm`, recucing memory requirements and computation time.

A number of other minor changes are also included in this PR.