### PR TITLE
Alternative version of `indexed_shape` with a different name

### DIFF
--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -107,9 +107,15 @@ def slice_length(length: int, idx: AxisIndex) -> Optional[int]:
 def indexed_shape(shape: Shape, idx: ArrayIndex) -> Tuple[int, ...]:
     """Determine the shape of an array after indexing/slicing.
 
+    The indexed shape is determined by replicating the observed effects
+    of NumPy/JAX array indexing/slicing syntax. It is significantly
+    faster than :func:`.jax_indexed_shape`, and has a minimal memory
+    footprint in all circumstances.
+
     Args:
         shape: Shape of array.
-        idx: Indexing expression.
+        idx: Indexing expression (singleton or tuple of `Ellipsis`,
+           `int`, `slice`, or ``None`` (`np.newaxis`)).
 
     Returns:
         Shape of indexed/sliced array.
@@ -134,6 +140,46 @@ def indexed_shape(shape: Shape, idx: ArrayIndex) -> Tuple[int, ...]:
             continue
         idx_shape[axis + offset + newaxis] = slice_length(shape[axis + offset], ax_idx)
     return tuple(filter(lambda x: x is not None, idx_shape))  # type: ignore
+
+
+def jax_indexed_shape(shape: Shape, idx: ArrayIndex) -> Tuple[int, ...]:
+    """Determine the shape of an array after indexing/slicing.
+
+    The indexed shape is determined by constructing and indexing an array
+    of the appropriate shape, relying on :func:`jax.jit` to avoid memory
+    allocation. It is potentially more reliable than
+    :func:`.indexed_shape` because the indexing/slicing calculations are
+    referred to JAX, but is significantly slower, and will involved
+    potentially significant memory allocations if JIT is disabled, e.g.
+    for debugging purposes.
+
+    Args:
+        shape: Shape of array.
+        idx: Indexing expression (singleton or tuple of `Ellipsis`,
+           `int`, `slice`, or ``None`` (`np.newaxis`)).
+
+    Returns:
+        Shape of indexed/sliced array.
+    """
+    if not isinstance(idx, tuple):
+        idx = (idx,)
+
+    # Convert any slices to its representation (slice, (start, stop, step))
+    # allowing hashing, needed for jax.jit
+    idx = tuple(exp.__reduce__() if isinstance(exp, slice) else exp for exp in idx)
+
+    def get_shape(in_shape, ind_expr):
+        # convert slices representations back to slices
+        ind_expr = tuple(
+            (slice(*exp[1]) if isinstance(exp, tuple) and len(exp) > 0 and exp[0] == slice else exp)
+            for exp in ind_expr
+        )
+        return jax.numpy.empty(in_shape)[ind_expr].shape
+
+    # This compiles each time it gets new arguments because all arguments are static.
+    f = jax.jit(get_shape, static_argnums=(0, 1))
+
+    return tuple(t.item() for t in f(shape, idx))  # type: ignore
 
 
 def no_nan_divide(

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -10,6 +10,7 @@ from scico.numpy.util import (
     is_nested,
     is_real_dtype,
     is_scalar_equiv,
+    jax_indexed_shape,
     no_nan_divide,
     parse_axes,
     real_dtype,
@@ -108,6 +109,7 @@ def test_slice_length_other(length, slc):
 def test_indexed_shape(shape, slc):
     x = np.zeros(shape)
     assert x[slc].shape == indexed_shape(shape, slc)
+    assert x[slc].shape == jax_indexed_shape(shape, slc)
 
 
 def test_is_nested():


### PR DESCRIPTION
This is a replacement for #519, adopting the new  version of `indexed_shape` as an alternative rather than a replacement.