### PR TITLE
Improve docs for `linop.xray` subpackage

### DIFF
--- a/docs/source/conf/20-extensions.py
+++ b/docs/source/conf/20-extensions.py
@@ -11,6 +11,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
     "sphinx.ext.inheritance_diagram",
+    "matplotlib.sphinxext.plot_directive",
     "sphinx.ext.todo",
     "nbsphinx",
 ]

--- a/scico/linop/xray/__init__.py
+++ b/scico/linop/xray/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023 by SCICO Developers
+# Copyright (C) 2023-2024 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -14,6 +14,16 @@ same as the Radon transform for projections in two dimensions, these two
 transform differ in higher numbers of dimensions, and it is the X-ray
 transform that is the appropriate mathematical model for beam attenuation
 based imaging in three or more dimensions.
+
+|
+
+.. plot:: figures/xray_2d_geom.py
+   :align: center
+   :include-source: False
+   :show-source-link: False
+   :caption: Comparison of 2D X-ray projector geometries
+
+|
 """
 
 import sys

--- a/scico/linop/xray/__init__.py
+++ b/scico/linop/xray/__init__.py
@@ -26,7 +26,14 @@ as illustrated in the figure below.
    :align: center
    :include-source: False
    :show-source-link: False
-   :caption: Comparison of 2D X-ray projector geometries
+   :caption: Comparison of 2D X-ray projector geometries. The red arrows
+      are are directed towards the detector, which is oriented with pixel
+      indices ordered in the same direction as clockwise rotation (e.g.
+      in the "scico" geometry, the :math:`\theta=0` projection
+      corresponds to row sums ordered from the top to the bottom of the
+      figure, while the :math:`\theta=\pi` projection
+      corresponds to row sums ordered from the bottom to the top of the
+      figure).
 
 |
 

--- a/scico/linop/xray/__init__.py
+++ b/scico/linop/xray/__init__.py
@@ -5,7 +5,7 @@
 # user license can be found in the 'LICENSE' file distributed with the
 # package.
 
-"""X-ray transform classes.
+r"""X-ray transform classes.
 
 The tomographic projections that are frequently referred to as Radon
 transforms are referred to as X-ray transforms in SCICO. While the Radon
@@ -15,7 +15,12 @@ transform differ in higher numbers of dimensions, and it is the X-ray
 transform that is the appropriate mathematical model for beam attenuation
 based imaging in three or more dimensions.
 
-|
+SCICO includes its own integrated 2D X-ray transform, and also provides
+interfaces to those implemented in the
+`ASTRA toolbox <https://github.com/astra-toolbox/astra-toolbox>`_
+and the `svmbir <https://github.com/cabouman/svmbir>`_ package. Each of
+these transforms uses a different convention for view angle directions,
+as illustrated in the figure below.
 
 .. plot:: figures/xray_2d_geom.py
    :align: center
@@ -24,6 +29,17 @@ based imaging in three or more dimensions.
    :caption: Comparison of 2D X-ray projector geometries
 
 |
+
+The conversion from the SCICO projection angle convention to those of the
+other two transforms is
+
+.. math::
+
+   \begin{aligned}
+   \theta_{\text{astra}} &= \theta_{\text{scico}} - \frac{\pi}{2} \\
+   \theta_{\text{svmbir}} &= 2 \pi - \theta_{\text{scico}} \;.
+   \end{aligned}
+
 """
 
 import sys

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 from math import prod
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 


### PR DESCRIPTION
Improve docs for `linop.xray` subpackage. See also lanl/scico-data#49.

The effects of the changes in the built docs may be viewed [here](https://scico--533.org.readthedocs.build/en/533/_autosummary/scico.linop.xray.html#module-scico.linop.xray). These docs are likely to be moved or edited as part of the completion of #529.