### PR TITLE
Bump maximum supported jax version to 0.4.31

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Version 0.0.6   (unreleased)
 • Rename ``scico.flax.save_weights`` and ``scico.flax.load_weights`` to
   ``scico.flax.save_variables`` and ``scico.flax.load_variables``
   respectively.
-• Support ``jaxlib`` and ``jax`` versions 0.4.3 to 0.4.30.
+• Support ``jaxlib`` and ``jax`` versions 0.4.3 to 0.4.31.
 • Support ``flax`` versions 0.8.0 to 0.8.3.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ scipy>=1.6.0
 imageio>=2.17
 tifffile
 matplotlib
-jaxlib>=0.4.3,<=0.4.30
-jax>=0.4.3,<=0.4.30
+jaxlib>=0.4.3,<=0.4.31
+jax>=0.4.3,<=0.4.31
 orbax-checkpoint<=0.5.7
 flax>=0.8.0,<=0.8.3
 pyabel>=0.9.0


### PR DESCRIPTION
Bump maximum supported jax version to 0.4.31.