### PR TITLE
Changes required to support `jax` version 0.4.33

### DIFF
--- a/.github/workflows/pytest_ubuntu.yml
+++ b/.github/workflows/pytest_ubuntu.yml
@@ -60,7 +60,8 @@ jobs:
           pip install pytest-split
           pip install -r requirements.txt
           pip install -r dev_requirements.txt
-          conda install -c conda-forge svmbir>=0.3.3
+          # svmbir install temporarily disabled due to import errors
+          #conda install -c conda-forge svmbir>=0.3.3
           conda install -c conda-forge astra-toolbox
           conda install -c conda-forge pyyaml
           pip install --upgrade --force-reinstall scipy>=1.6.0  # Temporary fix for GLIBCXX_3.4.30 not found in conda forge version

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -87,7 +87,7 @@ can be installed from PyPI
 From GitHub
 -----------
 
-The development version SCICO can be downloaded from the `GitHub repo
+The development version of SCICO can be downloaded from the `GitHub repo
 <https://github.com/lanl/scico>`_. Note that, since the SCICO repo has
 a submodule, it should be cloned via the command
 ::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -87,7 +87,7 @@ can be installed from PyPI
 From GitHub
 -----------
 
-SCICO can be downloaded from the `GitHub repo
+The development version SCICO can be downloaded from the `GitHub repo
 <https://github.com/lanl/scico>`_. Note that, since the SCICO repo has
 a submodule, it should be cloned via the command
 ::
@@ -100,6 +100,13 @@ Install using the commands
    cd scico
    pip install -r requirements.txt
    pip install -e .
+
+
+If a clone of the SCICO repository is not needed, it is simpler to
+install directly using ``pip``
+::
+
+   pip install git+https://github.com/lanl/scico
 
 
 

--- a/examples/scripts/ct_astra_modl_train_foam2.py
+++ b/examples/scripts/ct_astra_modl_train_foam2.py
@@ -54,6 +54,11 @@ ray.init(logging_level=logging.ERROR)  # need to call init before jax import: ra
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from scico import flax as sflax
@@ -67,7 +72,7 @@ Prepare parallel processing. Set an arbitrary processor count (only
 applies if GPU is not available).
 """
 os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/examples/scripts/ct_astra_odp_train_foam2.py
+++ b/examples/scripts/ct_astra_odp_train_foam2.py
@@ -61,6 +61,11 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from scico import flax as sflax
@@ -70,7 +75,7 @@ from scico.flax.train.traversals import clip_positive, construct_traversal
 from scico.linop.xray.astra import XRayTransform2D
 
 
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/examples/scripts/ct_astra_unet_train_foam2.py
+++ b/examples/scripts/ct_astra_unet_train_foam2.py
@@ -27,6 +27,11 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 import numpy as np
 
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -36,7 +41,7 @@ from scico import metric, plot
 from scico.flax.examples import load_ct_data
 
 
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/examples/scripts/deconv_modl_train_foam1.py
+++ b/examples/scripts/deconv_modl_train_foam1.py
@@ -58,6 +58,11 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from scico import flax as sflax
@@ -67,7 +72,7 @@ from scico.flax.train.traversals import clip_positive, construct_traversal
 from scico.linop import CircularConvolve
 
 
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/examples/scripts/deconv_odp_train_foam1.py
+++ b/examples/scripts/deconv_odp_train_foam1.py
@@ -66,6 +66,11 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from scico import flax as sflax
@@ -75,7 +80,7 @@ from scico.flax.train.traversals import clip_positive, construct_traversal
 from scico.linop import CircularConvolve
 
 
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/examples/scripts/denoise_dncnn_train_bsds.py
+++ b/examples/scripts/denoise_dncnn_train_bsds.py
@@ -24,6 +24,11 @@ os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
 
 import jax
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from scico import flax as sflax
@@ -31,7 +36,7 @@ from scico import metric, plot
 from scico.flax.examples import load_image_data
 
 
-platform = jax.lib.xla_bridge.get_backend().platform
+platform = get_backend().platform
 print("Platform: ", platform)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ tifffile
 matplotlib
 jaxlib>=0.4.3,<=0.4.33
 jax>=0.4.3,<=0.4.33
-orbax-checkpoint<=0.5.7
+orbax-checkpoint>=0.5.0
 flax>=0.8.0,<=0.9.0
 pyabel>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ scipy>=1.6.0
 imageio>=2.17
 tifffile
 matplotlib
-jaxlib>=0.4.3,<=0.4.31
-jax>=0.4.3,<=0.4.31
+jaxlib>=0.4.3,<=0.4.33
+jax>=0.4.3,<=0.4.33
 orbax-checkpoint<=0.5.7
-flax>=0.8.0,<=0.8.3
+flax>=0.8.0,<=0.9.0
 pyabel>=0.9.0

--- a/scico/flax/examples/data_generation.py
+++ b/scico/flax/examples/data_generation.py
@@ -45,6 +45,11 @@ else:
 import jax
 import jax.numpy as jnp
 
+try:
+    from jax.extend.backend import get_backend  # introduced in jax 0.4.33
+except ImportError:
+    from jax.lib.xla_bridge import get_backend
+
 from scico.linop import CircularConvolve
 from scico.numpy import Array
 
@@ -260,7 +265,7 @@ def generate_ct_data(
     fbp = (fbp - fbp.min()) / (fbp.max() - fbp.min())
 
     if verbose:  # pragma: no cover
-        platform = jax.lib.xla_bridge.get_backend().platform
+        platform = get_backend().platform
         print(f"{'Platform':26s}{':':4s}{platform}")
         print(f"{'Device count':26s}{':':4s}{jax.device_count()}")
         print(f"{'Data generation':19s}{'time[s]:':10s}{time_dtgen:>7.2f}")
@@ -333,7 +338,7 @@ def generate_blur_data(
     blurn = jnp.clip(blurn, 0, 1)
 
     if verbose:  # pragma: no cover
-        platform = jax.lib.xla_bridge.get_backend().platform
+        platform = get_backend().platform
         print(f"{'Platform':26s}{':':4s}{platform}")
         print(f"{'Device count':26s}{':':4s}{jax.device_count()}")
         print(f"{'Data generation':19s}{'time[s]:':10s}{time_dtgen:>7.2f}")

--- a/scico/flax/train/checkpoints.py
+++ b/scico/flax/train/checkpoints.py
@@ -89,7 +89,7 @@ def checkpoint_save(state: TrainState, config: ConfigDict, workdir: Union[str, P
         # Remove non-serializable partial functools in post_lst if it exists
         config_ = config.copy()
         if "post_lst" in config_:
-            config_.pop("post_lst", None)
+            config_.pop("post_lst", None)  # type: ignore
         mngr.save(
             step,
             args=ocp.args.Composite(

--- a/scico/flax/train/checkpoints.py
+++ b/scico/flax/train/checkpoints.py
@@ -86,14 +86,15 @@ def checkpoint_save(state: TrainState, config: ConfigDict, workdir: Union[str, P
             options=options,
         )
         step = int(state.step)
-        print(f"step: {step}")
-        print(f"state: {state}")
-        print(f"config: {config}")
+        # Remove non-serializable partial functools in post_lst if it exists
+        config_ = config.copy()
+        if "post_lst" in config_:
+            config_.pop("post_lst", None)
         mngr.save(
             step,
             args=ocp.args.Composite(
                 state=ocp.args.StandardSave(state),
-                config=ocp.args.JsonSave(config),
+                config=ocp.args.JsonSave(config_),
             ),
         )
         mngr.wait_until_finished()

--- a/scico/flax/train/checkpoints.py
+++ b/scico/flax/train/checkpoints.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2022-2023 by SCICO Developers
+# Copyright (C) 2022-2024 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the

--- a/scico/functional/_denoiser.py
+++ b/scico/functional/_denoiser.py
@@ -128,7 +128,8 @@ class DnCNN(Functional):
         r"""Apply DnCNN denoiser.
 
         *Warning*: The `lam` parameter is ignored, and has no effect on
-        the output.
+        the output for :class:`.DnCNN` objects initialized with
+        :code:`variant` parameter values other than `6N` and `17N`.
 
         Args:
             x: Input array.

--- a/scico/numpy/_blockarray.py
+++ b/scico/numpy/_blockarray.py
@@ -174,9 +174,6 @@ for prop_name in da_props:
 def _da_method_wrapper(method_name):
     method = getattr(Array, method_name)
 
-    if method.__name__ is None or method.__qualname__ is None:
-        return method
-
     # Don't try to set attributes that are None. Not clear why some
     # functions/methods (e.g. block_until_ready) have None values
     # for these attributes.

--- a/scico/numpy/_blockarray.py
+++ b/scico/numpy/_blockarray.py
@@ -8,7 +8,7 @@
 """Block array class."""
 
 import inspect
-from functools import wraps
+from functools import WRAPPER_ASSIGNMENTS, wraps
 from typing import Callable
 
 import jax
@@ -174,10 +174,18 @@ for prop_name in da_props:
 def _da_method_wrapper(method_name):
     method = getattr(Array, method_name)
 
-    if method.__name__ is None:
+    if method.__name__ is None or method.__qualname__ is None:
         return method
 
-    @wraps(method)
+    # Don't try to set attributes that are None. Not clear why some
+    # functions/methods (e.g. block_until_ready) have None values
+    # for these attributes.
+    wrapper_assignments = WRAPPER_ASSIGNMENTS
+    for attr in ("__name__", "__qualname__"):
+        if getattr(method, attr) is None:
+            wrapper_assignments = tuple(x for x in wrapper_assignments if x != attr)
+
+    @wraps(method, assigned=wrapper_assignments)
     def method_ba(self, *args, **kwargs):
         result = tuple(getattr(x, method_name)(*args, **kwargs) for x in self)
 

--- a/scico/numpy/_wrapped_function_lists.py
+++ b/scico/numpy/_wrapped_function_lists.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2022-2023 by SCICO Developers
+# Copyright (C) 2022-2024 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SPORCO package. Details of the copyright
 # and user license can be found in the 'LICENSE.txt' file distributed
@@ -84,7 +84,7 @@ mathematical_functions = (
     "arccosh",
     "arctanh",
     "around",
-    "round_",
+    "round",
     "rint",
     "fix",
     "floor",


### PR DESCRIPTION
Changes required to support `jax` version 0.4.33, switch to using the new `orbax-checkpoint`  `CheckpointManager` API, and various other improvements.