### PR TITLE
Bump `jax` and `flax` version upper bounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Version 0.0.7   (unreleased)
 
 • New module ``scico.trace`` for tracing function/method calls.
 • Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.4.37.
-• Support ``flax`` versions 0.8.0 to 0.10.*.
+• Support ``flax`` versions 0.8.0 to 0.10.2.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Version 0.0.7   (unreleased)
 ----------------------------
 
 • New module ``scico.trace`` for tracing function/method calls.
+• Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.4.37.
+• Support ``flax`` versions 0.8.0 to 0.10.*.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ matplotlib
 jaxlib>=0.4.13,<=0.4.37
 jax>=0.4.13,<=0.4.37
 orbax-checkpoint>=0.5.0
-flax>=0.8.0,<=0.10.*
+flax>=0.8.0,<=0.10.2
 pyabel>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ scipy>=1.6.0
 imageio>=2.17
 tifffile
 matplotlib
-jaxlib>=0.4.13,<=0.4.35
-jax>=0.4.13,<=0.4.35
+jaxlib>=0.4.13,<=0.4.37
+jax>=0.4.13,<=0.4.37
 orbax-checkpoint>=0.5.0
-flax>=0.8.0,<=0.10.0
+flax>=0.8.0,<=0.10.*
 pyabel>=0.9.0


### PR DESCRIPTION
Bump `jax` and `flax` version upper bounds. Resolves #571.