### PR TITLE
Resolve failure with `jax` 0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Version 0.0.7   (unreleased)
   a functional composed with an orthogonal linear operator.
 • New optimizer methods ``save_state`` and ``load_state`` supporting
   algorithm state checkpointing.
-• Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.5.3.
+• Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.6.0.
 • Support ``flax`` versions 0.8.0 to 0.10.2.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ scipy>=1.11.0
 imageio>=2.17
 tifffile
 matplotlib
-jaxlib>=0.4.13,<=0.5.3
-jax>=0.4.13,<=0.5.3
+jaxlib>=0.4.13,<=0.6.0
+jax>=0.4.13,<=0.6.0
 orbax-checkpoint>=0.5.0
 flax>=0.8.0,<=0.10.2
 pyabel>=0.9.0

--- a/scico/random.py
+++ b/scico/random.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2023 by SCICO Developers
+# Copyright (C) 2020-2025 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -80,8 +80,14 @@ def _add_seed(fun):
            are unchanged.
     """
 
-    # find number of arguments to fun
-    num_params = len(inspect.signature(fun).parameters)
+    # find number of non-keyword-only parameters of fun
+    num_params = len(
+        [
+            param
+            for param in inspect.signature(fun).parameters.values()
+            if param.kind != param.KEYWORD_ONLY
+        ]
+    )
 
     def fun_alt(*args, key=None, seed=None, **kwargs):
 


### PR DESCRIPTION
Fix bug resulting from introduction of new keyword-only parameter for `jax.random` functions.