### PR TITLE
Changes to `BlockArray` and gradient operators

### DIFF
--- a/examples/scripts/denoise_ptv_pdhg.py
+++ b/examples/scripts/denoise_ptv_pdhg.py
@@ -82,7 +82,7 @@ Denoise with polar total variation for comparison.
 g_plr = λ_plr * functional.L1Norm()
 
 G = linop.PolarGradient(input_shape=x_gt.shape)
-D = linop.Diagonal(snp.array([0.3, 1.0]).reshape((2,1,1)), input_shape=G.shape[0])
+D = linop.Diagonal(snp.array([0.3, 1.0]).reshape((2, 1, 1)), input_shape=G.shape[0])
 C = D @ G
 
 tau, sigma = PDHG.estimate_parameters(C, ratio=20.0)

--- a/examples/scripts/denoise_ptv_pdhg.py
+++ b/examples/scripts/denoise_ptv_pdhg.py
@@ -82,7 +82,7 @@ Denoise with polar total variation for comparison.
 g_plr = λ_plr * functional.L1Norm()
 
 G = linop.PolarGradient(input_shape=x_gt.shape)
-D = linop.Diagonal(snp.blockarray([0.3, 1.0]), input_shape=G.shape[0])
+D = linop.Diagonal(snp.array([0.3, 1.0]).reshape((2,1,1)), input_shape=G.shape[0])
 C = D @ G
 
 tau, sigma = PDHG.estimate_parameters(C, ratio=20.0)

--- a/scico/linop/_grad.py
+++ b/scico/linop/_grad.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import scico.numpy as snp
 from scico.numpy import Array, BlockArray
-from scico.typing import BlockShape, DType, Shape
+from scico.typing import DType, Shape
 
 from ._linop import LinearOperator
 
@@ -88,6 +88,19 @@ class ProjectedGradient(LinearOperator):
         jit: bool = True,
     ):
         r"""
+
+        The result of applying the operator is always a
+        :class:`jax.Array`. If `coord` is a singleton tuple, it has the
+        same shape as the input array. Otherwise, the gradients for each
+        of the local coordinate axes are stacked on an additional axis at
+        index 0.
+
+        If `coord` is ``None``, which is the default, gradients are
+        computed in the standard axis-aligned coordinate system, and the
+        shape of the returned array depends on the number of axes on
+        which the gradient is calculated, as specified explicitly or
+        implicitly via the `axes` parameter.
+
         Args:
             input_shape: Shape of input array.
             axes: Axes over which to compute the gradient. Defaults to
@@ -103,16 +116,7 @@ class ProjectedGradient(LinearOperator):
                 :math:`i^{\mrm{th}}` axis. If it is the latter, it should
                 consist of :math:`N` blocks, each of which has a shape
                 that is suitable for multiplication with an array of
-                shape :math:`M_0 \times M_1 \times \ldots`. If `coord` is
-                a singleton tuple, the result of applying the operator is
-                a :class:`jax.Array`; otherwise it consists of the
-                gradients for each of the local coordinate axes in
-                `coord` stacked into a :class:`.BlockArray`. If `coord`
-                is ``None``, which is the default, gradients are computed
-                in the standard axis-aligned coordinate system, and the
-                return type depends on the number of axes on which the
-                gradient is calculated, as specified explicitly or
-                implicitly via the `axes` parameter.
+                shape :math:`M_0 \times M_1 \times \ldots`.
             cdiff: If ``True``, estimate gradients using the second order
                 central different returned by :func:`snp.gradient`,
                 otherwise use the first order asymmetric difference
@@ -133,19 +137,19 @@ class ProjectedGradient(LinearOperator):
                     f"len(input_shape)={len(input_shape)}."
                 )
             self.axes = axes
-        output_shape: Union[Shape, BlockShape]
+        output_shape: Shape
         if coord is None:
             # If coord is None, output shape is determined by number of axes.
             if len(self.axes) == 1:
                 output_shape = input_shape
             else:
-                output_shape = (input_shape,) * len(self.axes)
+                output_shape = (len(self.axes),) + input_shape
         else:
             # If coord is not None, output shape is determined by number of coord arrays.
             if len(coord) == 1:
                 output_shape = input_shape
             else:
-                output_shape = (input_shape,) * len(coord)
+                output_shape = (len(coord),) + input_shape
         self.coord = coord
         self.cdiff = cdiff
         super().__init__(
@@ -159,23 +163,23 @@ class ProjectedGradient(LinearOperator):
     def _eval(self, x: Array) -> Union[Array, BlockArray]:
 
         if self.cdiff:
-            grad = snp.gradient(x, axis=self.axes)
+            grad = snp.stack(snp.gradient(x, axis=self.axes))
         else:
             grad = diffstack(x, axis=self.axes)
         if self.coord is None:
             # If coord attribute is None, just return gradients on specified axes.
             if len(self.axes) == 1:
-                return grad
+                return grad[0]
             else:
-                return snp.blockarray(grad)
+                return grad
         else:
             # If coord attribute is not None, return gradients projected onto specified local
             # coordinate systems.
-            projgrad = [sum([c[m] * grad[m] for m in range(len(grad))]) for c in self.coord]
+            projgrad = [sum([c[m] * grad[m] for m in range(len(self.axes))]) for c in self.coord]
             if len(self.coord) == 1:
                 return projgrad[0]
             else:
-                return snp.blockarray(projgrad)
+                return snp.stack(projgrad)
 
 
 class PolarGradient(ProjectedGradient):
@@ -193,8 +197,9 @@ class PolarGradient(ProjectedGradient):
     |
 
     If only one of `angular` and `radial` is ``True``, the operator
-    output is a :class:`jax.Array`, otherwise it is a
-    :class:`.BlockArray`.
+    output has the same shape as the input, otherwise the gradients for
+    the two local coordinate axes are stacked on an additional axis at
+    index 0.
     """
 
     def __init__(
@@ -289,8 +294,9 @@ class CylindricalGradient(ProjectedGradient):
     |
 
     If only one of `angular`, `radial`, and `axial` is ``True``, the
-    operator output is a :class:`jax.Array`, otherwise it is a
-    :class:`.BlockArray`.
+    operator output has the same shape as the input, otherwise the
+    gradients for the selected local coordinate axes are stacked on an
+    additional axis at index 0.
     """
 
     def __init__(
@@ -414,8 +420,9 @@ class SphericalGradient(ProjectedGradient):
     |
 
     If only one of `azimuthal`, `polar`, and `radial` is ``True``, the
-    operator output is a :class:`jax.Array`, otherwise it is a
-    :class:`.BlockArray`.
+    operator output has the same shape as the input, otherwise the
+    gradients for the selected local coordinate axes are stacked on an
+    additional axis at index 0.
     """
 
     def __init__(

--- a/scico/numpy/__init__.py
+++ b/scico/numpy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2023 by SCICO Developers
+# Copyright (C) 2020-2025 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the

--- a/scico/numpy/_blockarray.py
+++ b/scico/numpy/_blockarray.py
@@ -9,12 +9,10 @@
 
 import inspect
 from functools import WRAPPER_ASSIGNMENTS, wraps
-from typing import Callable, Sequence, Tuple, Union
+from typing import Callable
 
 import jax
 import jax.numpy as jnp
-
-from scico.typing import BlockShape, Shape
 
 from ._wrapped_function_lists import binary_ops, unary_ops
 from .util import is_collapsible
@@ -94,6 +92,21 @@ class BlockArray:
         return f"BlockArray({repr(self.arrays)})"
 
     def stack(self, axis=0):
+        """Collapse a :class:`.BlockArray` to :class:`jax.Array`.
+
+        Collapse a :class:`.BlockArray` to :class:`jax.Array` by stacking
+        the blocks on axis `axis`.
+
+        Args:
+            axis: Index of new axis on which blocks are to be stacked.
+
+        Returns:
+            A :class:`jax.Array` obtained by stacking.
+
+        Raises:
+            ValueError: When called on a :class:`.BlockArray` that is not
+               stackable.
+        """
         if is_collapsible(self.shape):
             return jnp.stack(self.arrays, axis=axis)
         else:

--- a/scico/numpy/_blockarray.py
+++ b/scico/numpy/_blockarray.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2024 by SCICO Developers
+# Copyright (C) 2020-2025 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SPORCO package. Details of the copyright
 # and user license can be found in the 'LICENSE.txt' file distributed
@@ -9,12 +9,15 @@
 
 import inspect
 from functools import WRAPPER_ASSIGNMENTS, wraps
-from typing import Callable
+from typing import Callable, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 
+from scico.typing import BlockShape, Shape
+
 from ._wrapped_function_lists import binary_ops, unary_ops
+from .util import is_collapsible
 
 # Determine type of "standard" jax array since jax.Array is an abstract
 # base class type that is not suitable for use here.
@@ -89,6 +92,14 @@ class BlockArray:
 
     def __repr__(self):
         return f"BlockArray({repr(self.arrays)})"
+
+    def stack(self, axis=0):
+        if is_collapsible(self.shape):
+            return jnp.stack(self.arrays, axis=axis)
+        else:
+            raise ValueError(
+                f"BlockArray of shape {self.shape} cannot be " "collapsed to an Array."
+            )
 
 
 # Register BlockArray as a jax pytree, without this, jax autograd won't work.

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -54,7 +54,7 @@ def transpose_list_of_ntpl(ntlist: List[NamedTuple]) -> NamedTuple:
     return cls(*[[ntlist[m][n] for m in range(numentry)] for n in range(nfields)])  # type: ignore
 
 
-def namedtuple_to_array(ntpl: NamedTuple) -> Array:
+def namedtuple_to_array(ntpl: NamedTuple) -> snp.Array:
     """Convert a namedtuple to an array.
 
     Convert a :func:`collections.namedtuple` object to a
@@ -76,7 +76,7 @@ def namedtuple_to_array(ntpl: NamedTuple) -> Array:
     )
 
 
-def array_to_namedtuple(array: Array) -> NamedTuple:
+def array_to_namedtuple(array: snp.Array) -> NamedTuple:
     """Convert an array representation of a namedtuple back to a namedtuple.
 
     Convert a :class:`numpy.ndarray` object constructed by

--- a/scico/operator/_stack.py
+++ b/scico/operator/_stack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023-2024 by SCICO Developers
+# Copyright (C) 2023-2025 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -19,7 +19,7 @@ from typing_extensions import TypeGuard
 
 import scico.numpy as snp
 from scico.numpy import Array, BlockArray
-from scico.numpy.util import is_nested
+from scico.numpy.util import is_blockable, is_collapsible, is_nested
 from scico.typing import BlockShape, Shape
 
 from ._operator import Operator
@@ -43,22 +43,6 @@ def collapse_shapes(
     raise ValueError(
         "Combining these shapes would result in a twice-nested BlockArray, which is not supported."
     )
-
-
-def is_collapsible(shapes: Sequence[Union[Shape, BlockShape]]) -> bool:
-    """Determine whether a sequence of shapes can be collapsed.
-
-    Return ``True`` if the a list of shapes represent arrays that can
-    be stacked, i.e., they are all the same."""
-    return all(s == shapes[0] for s in shapes)
-
-
-def is_blockable(shapes: Sequence[Union[Shape, BlockShape]]) -> TypeGuard[Union[Shape, BlockShape]]:
-    """Determine whether a sequence of shapes could be a :class:`BlockArray` shape.
-
-    Return ``True`` if the sequence of shapes represent arrays that can
-    be combined into a :class:`BlockArray`, i.e., none are nested."""
-    return not any(is_nested(s) for s in shapes)
 
 
 class VerticalStack(Operator):

--- a/scico/test/linop/test_grad.py
+++ b/scico/test/linop/test_grad.py
@@ -7,9 +7,34 @@ import jax
 import pytest
 
 import scico.numpy as snp
-from scico.linop import CylindricalGradient, PolarGradient, SphericalGradient
-from scico.numpy import Array, BlockArray
+from scico.linop import (
+    CylindricalGradient,
+    PolarGradient,
+    ProjectedGradient,
+    SphericalGradient,
+)
+from scico.numpy import Array
 from scico.random import randn
+
+
+def test_proj_grad():
+    x = snp.ones((4, 5))
+
+    P = ProjectedGradient(x.shape, axes=(0,))
+    assert P(x).shape == (4, 5)
+
+    P = ProjectedGradient(x.shape)
+    assert P(x).shape == (2, 4, 5)
+
+    P = ProjectedGradient(x.shape, coord=(np.arange(0, 4)[:, np.newaxis],))
+    assert P(x).shape == (4, 5)
+
+    coord = (
+        snp.blockarray([snp.array([0.0]), snp.array([1.0])]),
+        snp.blockarray([snp.array([1.0]), snp.array([0.0])]),
+    )
+    P = ProjectedGradient(x.shape, coord=coord)
+    assert P(x).shape == (2, 4, 5)
 
 
 class TestPolarGradient:

--- a/scico/test/linop/test_grad.py
+++ b/scico/test/linop/test_grad.py
@@ -54,13 +54,11 @@ class TestPolarGradient:
             jit=jit,
         )
         Ax = A @ x
+        assert isinstance(Ax, Array)
         if angular and radial:
-            assert isinstance(Ax, BlockArray)
-            assert len(Ax.shape) == 2
-            assert Ax[0].shape == input_shape
-            assert Ax[1].shape == input_shape
+            assert Ax.shape[0] == 2
+            assert Ax.shape[1:] == input_shape
         else:
-            assert isinstance(Ax, Array)
             assert Ax.shape == input_shape
         assert Ax.dtype == input_dtype
 
@@ -125,14 +123,12 @@ class TestCylindricalGradient:
             jit=jit,
         )
         Ax = A @ x
+        assert isinstance(Ax, Array)
         Nc = sum([angular, radial, axial])
         if Nc > 1:
-            assert isinstance(Ax, BlockArray)
-            assert len(Ax) == Nc
-            for n in range(Nc):
-                assert Ax[n].shape == input_shape
+            assert Ax.shape[0] == Nc
+            assert Ax.shape[1:] == input_shape
         else:
-            assert isinstance(Ax, Array)
             assert Ax.shape == input_shape
         assert Ax.dtype == input_dtype
 
@@ -198,14 +194,12 @@ class TestSphericalGradient:
             jit=jit,
         )
         Ax = A @ x
+        assert isinstance(Ax, Array)
         Nc = sum([azimuthal, polar, radial])
         if Nc > 1:
-            assert isinstance(Ax, BlockArray)
-            assert len(Ax) == Nc
-            for n in range(Nc):
-                assert Ax[n].shape == input_shape
+            assert Ax.shape[0] == Nc
+            assert Ax.shape[1:] == input_shape
         else:
-            assert isinstance(Ax, Array)
             assert Ax.shape == input_shape
         assert Ax.dtype == input_dtype
 

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -399,3 +399,12 @@ def test_method():
     expected = BlockArray([[3.0], [42.0]])
     assert_array_equal(actual, expected)
     assert actual.dtype == expected.dtype
+
+
+def test_stack():
+    x = BlockArray(([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]]))
+    assert x.stack().shape == (2, 3)
+    assert x.stack(axis=1).shape == (3, 2)
+    y = BlockArray(([[1.0, 2.0, 3.0], [0.0, 0.0]]))
+    with pytest.raises(ValueError):
+        z = y.stack()

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -9,6 +9,8 @@ from scico.numpy.util import (
     array_to_namedtuple,
     complex_dtype,
     indexed_shape,
+    is_blockable,
+    is_collapsible,
     is_complex_dtype,
     is_nested,
     is_real_dtype,
@@ -162,6 +164,20 @@ def test_is_nested():
 
     # tuple of lists + scalar
     assert is_nested(([1, 2], 3)) == True
+
+
+def test_is_collapsible():
+    shape1 = ((1, 2, 3), (1, 2, 3), (1, 3, 3))
+    shape2 = ((1, 2, 3), (1, 2, 3), (1, 2, 3))
+    assert not is_collapsible(shape1)
+    assert is_collapsible(shape2)
+
+
+def test_is_blockable():
+    shape1 = ((1, 2, 3), (1, 2, 3), (1, 2, 3))
+    shape2 = ((1, 2, 3), ((1, 2, 3), (1, 2, 3)))
+    assert is_blockable(shape1)
+    assert not is_blockable(shape2)
 
 
 def test_is_real_dtype():


### PR DESCRIPTION
* Modify non-Cartesian coordinate gradient operators to output `Array` instead of `BlockArray`.
* Add `stack` method to `BlockArray`