### PR TITLE
Bump `jaxlib`, `jax`, and `flax` version upper bounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,8 @@ Version 0.0.7   (unreleased)
   a functional composed with an orthogonal linear operator.
 • New optimizer methods ``save_state`` and ``load_state`` supporting
   algorithm state checkpointing.
-• Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.6.2.
-• Support ``flax`` versions 0.8.0 to 0.10.6.
+• Support ``jaxlib`` and ``jax`` versions 0.4.13 to 0.7.0.
+• Support ``flax`` versions 0.8.0 to 0.10.7.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ scipy>=1.11.0
 imageio>=2.17
 tifffile
 matplotlib
-jaxlib>=0.4.13,<=0.6.2
-jax>=0.4.13,<=0.6.2
+jaxlib>=0.4.13,<=0.7.0
+jax>=0.4.13,<=0.7.0
 orbax-checkpoint>=0.5.0
-flax>=0.8.0,<=0.10.6
+flax>=0.8.0,<=0.10.7
 pyabel>=0.9.0


### PR DESCRIPTION
Bump `jaxlib`, `jax`, and `flax` version upper bounds.