### PR TITLE
Workaround for import failure of hyperopt 0.2.7

### DIFF
--- a/.github/workflows/pytest_macos.yml
+++ b/.github/workflows/pytest_macos.yml
@@ -41,7 +41,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 0  # Increase this value to force cache reset
+          CACHE_NUMBER: 1  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details

--- a/.github/workflows/pytest_macos.yml
+++ b/.github/workflows/pytest_macos.yml
@@ -41,7 +41,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 1  # Increase this value to force cache reset
+          CACHE_NUMBER: 0  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details
@@ -61,6 +61,7 @@ jobs:
           pip install bm4d>=4.0.0
           pip install "ray[tune]>=2.44"
           pip install hyperopt
+          pip install setuptools<82.0.0  # workaround for hyperopt 0.2.7
           pip install pydantic
           pip install "orbax-checkpoint>=0.5.0"
           #conda install -c conda-forge svmbir>=0.4.0

--- a/.github/workflows/pytest_macos.yml
+++ b/.github/workflows/pytest_macos.yml
@@ -57,14 +57,14 @@ jobs:
           pip install pytest-split
           pip install -r requirements.txt
           pip install -r dev_requirements.txt
-          pip install bm3d>=4.0.0
-          pip install bm4d>=4.0.0
+          pip install "bm3d>=4.0.0"
+          pip install "bm4d>=4.0.0"
           pip install "ray[tune]>=2.44"
           pip install hyperopt
-          pip install setuptools<82.0.0  # workaround for hyperopt 0.2.7
+          pip install "setuptools<82.0.0"  # workaround for hyperopt 0.2.7
           pip install pydantic
           pip install "orbax-checkpoint>=0.5.0"
-          #conda install -c conda-forge svmbir>=0.4.0
+          #conda install -c conda-forge "svmbir>=0.4.0"
           conda install -c astra-toolbox astra-toolbox
           conda install -c conda-forge pyyaml
       # Install package to be tested

--- a/.github/workflows/pytest_ubuntu.yml
+++ b/.github/workflows/pytest_ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 3  # Increase this value to force cache reset
+          CACHE_NUMBER: 0  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details
@@ -69,6 +69,7 @@ jobs:
           pip install bm3d>=4.0.0
           pip install "ray[tune]>=2.44"
           pip install hyperopt
+          pip install setuptools<82.0.0  # workaround for hyperopt 0.2.7
           pip install pydantic
           pip install "orbax-checkpoint>=0.5.0"
           conda install -c conda-forge svmbir>=0.4.0

--- a/.github/workflows/pytest_ubuntu.yml
+++ b/.github/workflows/pytest_ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 2  # Increase this value to force cache reset
+          CACHE_NUMBER: 3  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details

--- a/.github/workflows/pytest_ubuntu.yml
+++ b/.github/workflows/pytest_ubuntu.yml
@@ -65,14 +65,14 @@ jobs:
           pip install pytest-split
           pip install -r requirements.txt
           pip install -r dev_requirements.txt
-          pip install bm4d>=4.2.2
-          pip install bm3d>=4.0.0
+          pip install "bm4d>=4.2.2"
+          pip install "bm3d>=4.0.0"
           pip install "ray[tune]>=2.44"
           pip install hyperopt
-          pip install setuptools<82.0.0  # workaround for hyperopt 0.2.7
+          pip install "setuptools<82.0.0"  # workaround for hyperopt 0.2.7
           pip install pydantic
           pip install "orbax-checkpoint>=0.5.0"
-          conda install -c conda-forge svmbir>=0.4.0
+          conda install -c conda-forge "svmbir>=0.4.0"
           conda install -c conda-forge astra-toolbox
           conda install -c conda-forge pyyaml
       # Install package to be tested

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -39,7 +39,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ hashFiles('examples/examples_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 1  # Increase this value to force cache reset
+          CACHE_NUMBER: 0  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -39,7 +39,7 @@ jobs:
           path: ${{ env.CONDA }}/envs
           key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev_requirements.txt') }}-${{ hashFiles('examples/examples_requirements.txt') }}-${{ env.CACHE_NUMBER }}
         env:
-          CACHE_NUMBER: 0  # Increase this value to force cache reset
+          CACHE_NUMBER: 1  # Increase this value to force cache reset
         id: cache
       # Display environment details
       - name: Display environment details

--- a/examples/examples_requirements.txt
+++ b/examples/examples_requirements.txt
@@ -6,6 +6,7 @@ astra-toolbox
 xdesign>=0.5.5
 ray[tune,train]>=2.44
 hyperopt
+setuptools<82.0.0  # workaround for hyperopt 0.2.7
 pydantic
 orbax-checkpoint>=0.5.0
 bm3d>=4.0.0

--- a/scico/examples.py
+++ b/scico/examples.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2021-2025 by SCICO Developers
+# Copyright (C) 2021-2026 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -180,9 +180,10 @@ def get_ucb_diffusercam_data(path: str, verbose: bool = False):  # pragma: no co
         verbose: Flag indicating whether to print status messages.
     """
 
-    # data source URL and filenames
+    # data source URL, filenames, and request header
     data_base_url = "https://github.com/Waller-Lab/DiffuserCam/blob/master/example_data/"
     data_files = ["example_psfs.mat", "example_raw.png"]
+    headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)", "Referer": data_base_url}
 
     # ensure path directory exists
     if not os.path.isdir(path):
@@ -194,7 +195,7 @@ def get_ucb_diffusercam_data(path: str, verbose: bool = False):  # pragma: no co
     for data_file in data_files:
         if verbose:
             print(f"Downloading {data_file} from {data_base_url}")
-        data = util.url_get(data_base_url + data_file + "?raw=true")
+        data = util.url_get(data_base_url + data_file + "?raw=true", headers=headers)
         f = open(os.path.join(temp_dir.name, data_file), "wb")
         f.write(data.read())
         f.close()

--- a/scico/test/test_util.py
+++ b/scico/test/test_util.py
@@ -91,11 +91,10 @@ def test_url_get():
     else:
         assert not uget.getvalue().find(b"SCICO") == -1
 
+    np.testing.assert_raises(ValueError, url_get, url, maxtry=-1)
+
     url = "about:blank"
     np.testing.assert_raises(urlerror.URLError, url_get, url)
-
-    url = "https://github.com/lanl/scico/blob/main/README.md"
-    np.testing.assert_raises(ValueError, url_get, url, maxtry=-1)
 
 
 def test_check_for_tracer():

--- a/scico/test/test_util.py
+++ b/scico/test/test_util.py
@@ -79,8 +79,12 @@ def _internet_connected(host="8.8.8.8", port=53, timeout=3):
 @pytest.mark.skipif(not _internet_connected(), reason="No internet connection")
 def test_url_get():
     url = "https://github.com/lanl/scico/blob/main/README.md"
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64)",
+        "Referer": "https://github.com/lanl/scico/blob/main",
+    }
     try:
-        uget = url_get(url)
+        uget = url_get(url, headers=headers)
     except urlerror.HTTPError as e:
         if e.code != 429:
             raise
@@ -91,7 +95,7 @@ def test_url_get():
     np.testing.assert_raises(urlerror.URLError, url_get, url)
 
     url = "https://github.com/lanl/scico/blob/main/README.md"
-    np.testing.assert_raises(ValueError, url_get, url, -1)
+    np.testing.assert_raises(ValueError, url_get, url, maxtry=-1)
 
 
 def test_check_for_tracer():

--- a/scico/test/test_util.py
+++ b/scico/test/test_util.py
@@ -79,7 +79,13 @@ def _internet_connected(host="8.8.8.8", port=53, timeout=3):
 @pytest.mark.skipif(not _internet_connected(), reason="No internet connection")
 def test_url_get():
     url = "https://github.com/lanl/scico/blob/main/README.md"
-    assert not url_get(url).getvalue().find(b"SCICO") == -1
+    try:
+        uget = url_get(url)
+    except urlerror.HTTPError as e:
+        if e.code != 429:
+            raise
+    else:
+        assert not uget.getvalue().find(b"SCICO") == -1
 
     url = "about:blank"
     np.testing.assert_raises(urlerror.URLError, url_get, url)

--- a/scico/util.py
+++ b/scico/util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2025 by SCICO Developers
+# Copyright (C) 2020-2026 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -146,11 +146,14 @@ def check_for_tracer(func: Callable) -> Callable:
     return wrapper
 
 
-def url_get(url: str, maxtry: int = 3, timeout: int = 10) -> io.BytesIO:  # pragma: no cover
+def url_get(
+    url: str, headers: Optional[dict] = None, maxtry: int = 3, timeout: int = 10
+) -> io.BytesIO:  # pragma: no cover
     """Get content of a file via a URL.
 
     Args:
         url: URL of the file to be downloaded.
+        headers: Dict of header strings for request.
         maxtry: Maximum number of download retries.
         timeout: Timeout in seconds for blocking operations.
 
@@ -161,12 +164,15 @@ def url_get(url: str, maxtry: int = 3, timeout: int = 10) -> io.BytesIO:  # prag
         ValueError: If the maxtry parameter is not greater than zero.
         urllib.error.URLError: If the file cannot be downloaded.
     """
-
     if maxtry <= 0:
         raise ValueError("Argument 'maxtry' should be greater than zero.")
+
+    if headers is None:
+        headers = {}
+    req = urlrequest.Request(url, headers=headers)
     for ntry in range(maxtry):
         try:
-            rspns = urlrequest.urlopen(url, timeout=timeout)
+            rspns = urlrequest.urlopen(req, timeout=timeout)
             cntnt = rspns.read()
             break
         except urlerror.URLError as e:


### PR DESCRIPTION
Workaround for import failure of `hyperopt` 0.2.7.