### PR TITLE
Make snp.ravel fully flatten a BlockArray

### DIFF
--- a/docs/source/include/blockarray.rst
+++ b/docs/source/include/blockarray.rst
@@ -96,15 +96,15 @@ For lists of the remaining wrapped functions, see
 
 Note that:
 
-* :func:`scico.numpy.ravel` returns a fully flattened, single
-  :class:`jax.Array`, while :meth:`.BlockArray.ravel` returns a
-  :class:`.BlockArray` with ravelled blocks.
 * The functional and method versions of the "same" function differ in their
   behavior, with the method version only applying the reduction within each
   block, and the function version applying the reduction across all blocks.
   For example, :func:`scico.numpy.sum` applied to a :class:`.BlockArray` with
   two blocks returns a scalar value, while :meth:`.BlockArray.sum` returns a
   :class:`.BlockArray` two scalar blocks.
+* For example, :func:`scico.numpy.ravel` returns a fully flattened, single
+  :class:`jax.Array`, while :meth:`.BlockArray.ravel` returns a
+  :class:`.BlockArray` with ravelled blocks.
 
 
 Motivating Example

--- a/docs/source/include/blockarray.rst
+++ b/docs/source/include/blockarray.rst
@@ -96,9 +96,9 @@ For lists of the remaining wrapped functions, see
 
 Note that:
 
-* Both :func:`scico.numpy.ravel` and :meth:`.BlockArray.ravel` return a
-  :class:`.BlockArray` with ravelled blocks rather than the concatenation
-  of these blocks as a single array.
+* :func:`scico.numpy.ravel` returns a fully flattened, single
+  :class:`jax.Array`, while :meth:`.BlockArray.ravel` returns a
+  :class:`.BlockArray` with ravelled blocks.
 * The functional and method versions of the "same" function differ in their
   behavior, with the method version only applying the reduction within each
   block, and the function version applying the reduction across all blocks.

--- a/scico/numpy/__init__.py
+++ b/scico/numpy/__init__.py
@@ -66,8 +66,7 @@ def ravel(ba: Union[Array | BlockArray]) -> Array:
     When called on an ``Array``, flattens the array.
 
     Args:
-        ba:
-           The :class:`BlockArray` to flatten.
+        ba: The :class:`BlockArray` to flatten.
 
     Returns:
         `ba` flattened into a single ``Array.``

--- a/scico/numpy/__init__.py
+++ b/scico/numpy/__init__.py
@@ -17,9 +17,11 @@ functions unique to SCICO in :mod:`.util`.
 
 import sys
 from functools import partial
+from typing import Union
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 from jax import Array
 
@@ -31,6 +33,8 @@ from ._wrapped_function_lists import (
     reduction_functions,
     testing_functions,
 )
+
+__all__ = ["fft", "linalg", "testing", "util"]
 
 # allow snp.blockarray(...) to create BlockArrays
 blockarray = BlockArray.blockarray
@@ -54,6 +58,25 @@ _wrappers.wrap_recursively(
 )
 _wrappers.wrap_recursively(vars(), mathematical_functions, _wrappers.map_func_over_args)
 _wrappers.wrap_recursively(vars(), reduction_functions, _wrappers.add_full_reduction)
+
+
+def ravel(ba: Union[Array | BlockArray]) -> Array:
+    """Completely flatten a :class:`BlockArray` into a single ``Array``.
+
+    When called on an ``Array``, flattens the array.
+
+    Args:
+        ba:
+           The :class:`BlockArray` to flatten.
+
+    Returns:
+        `ba` flattened into a single ``Array.``
+    """
+    if isinstance(ba, BlockArray):
+        return jax.numpy.concatenate([arr.flatten() for arr in ba])
+
+    return ba.ravel()
+
 
 # wrap testing funcs
 _wrappers.wrap_recursively(

--- a/scico/numpy/_wrapped_function_lists.py
+++ b/scico/numpy/_wrapped_function_lists.py
@@ -207,7 +207,6 @@ mathematical_functions = (
     "linalg.tensorinv",
     "shape",  # https://numpy.org/doc/stable/reference/routines.array-manipulation.html
     "reshape",
-    "ravel",
     "moveaxis",
     "rollaxis",
     "swapaxes",

--- a/scico/test/functional/test_core.py
+++ b/scico/test/functional/test_core.py
@@ -147,13 +147,13 @@ class TestNormProx:
         nrmobj = norm()
         nrm = nrmobj.__call__
         prx = nrmobj.prox
-        pf = nrmobj.prox(snp.concatenate(snp.ravel(test_prox_obj.vb)), alpha)
+        pf = nrmobj.prox(snp.ravel(test_prox_obj.vb), alpha)
         pf_b = nrmobj.prox(test_prox_obj.vb, alpha)
 
         assert pf.dtype == test_prox_obj.vb.dtype
         assert pf_b.dtype == test_prox_obj.vb.dtype
 
-        snp.testing.assert_allclose(pf, snp.concatenate(snp.ravel(pf_b)), rtol=1e-6)
+        snp.testing.assert_allclose(pf, snp.ravel(pf_b), rtol=1e-6)
 
     @pytest.mark.parametrize("norm", normlist)
     def test_prox_zeros(self, norm, test_prox_obj):

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -415,3 +415,19 @@ def test_stack():
     y = BlockArray(([[1.0, 2.0, 3.0], [0.0, 0.0]]))
     with pytest.raises(ValueError):
         z = y.stack()
+
+
+def test_ravel():
+    # snp.ravel completely flattens a BlockArray
+    ba = snp.ones([[2, 3], [3, 4]])
+    assert snp.ravel(ba).shape == (2 * 3 + 3 * 4,)
+
+    # snp.ravel also flattens an Array
+    arr = snp.ones((2, 3))
+    assert snp.ravel(arr).shape == (2 * 3,)
+
+    # ba.flatten maps over BlockArray blocks
+    assert ba.flatten().shape == ((2 * 3,), (3 * 4,))
+
+    # ba.ravel also maps over BlockArray blocks
+    assert ba.ravel().shape == ((2 * 3,), (3 * 4,))

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -241,7 +241,7 @@ REDUCTION_PARAMS = dict(
 def test_reduce(reduction_obj, func):
     x = func(reduction_obj.a)
     x_jit = jax.jit(func)(reduction_obj.a)
-    y = func(snp.concatenate(snp.ravel(reduction_obj.a)))
+    y = func(snp.ravel(reduction_obj.a))
     np.testing.assert_allclose(x, x_jit, rtol=1e-6)  # test jitted function
     np.testing.assert_allclose(x, y, rtol=1e-6)  # test for correctness
 
@@ -431,3 +431,14 @@ def test_ravel():
 
     # ba.ravel also maps over BlockArray blocks
     assert ba.ravel().shape == ((2 * 3,), (3 * 4,))
+
+    # snp.ravel works with scalar blocks
+    # fmt: off
+    scalar_ba = snp.ones(
+        [
+            [],
+            [1,],
+            [1, 1],
+        ]
+    )  # fmt: on
+    assert_array_equal(snp.ravel(scalar_ba), [1, 1, 1])


### PR DESCRIPTION
See the new test for the proposed behavior of `snp.ravel` `BlockArray.ravel` and `BlockArray.flatten`. Closes #637.