### PR TITLE
Make BlockArray work with eval_shape

### DIFF
--- a/scico/numpy/_blockarray.py
+++ b/scico/numpy/_blockarray.py
@@ -51,7 +51,7 @@ class BlockArray:
 
     def __init__(self, inputs):
         # convert inputs to jax arrays
-        self.arrays = [x if isinstance(x, jnp.ndarray) else jnp.array(x) for x in inputs]
+        self.arrays = [x if isinstance(x, jax.ShapeDtypeStruct) else jnp.array(x) for x in inputs]
 
         # check that dtypes match
         if not all(a.dtype == self.arrays[0].dtype for a in self.arrays):
@@ -76,7 +76,7 @@ class BlockArray:
         rather than a list.
         """
         result = self.arrays[key]
-        if not isinstance(result, jnp.ndarray):
+        if isinstance(result, list):
             return BlockArray(result)  # x[k:k+1] returns a BlockArray
         return result  # x[k] returns a jax array
 

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -425,6 +425,28 @@ def is_blockable(shapes: Sequence[Union[Shape, BlockShape]]) -> TypeGuard[Union[
     return not any(is_nested(s) for s in shapes)
 
 
+def shape_dtype_rep(
+    shape: Union[Shape, BlockShape], dtype: DType
+) -> Union[jax.ShapeDtypeStruct, snp.BlockArray]:
+    """Construct a representation of array or blockarray shape and dtype.
+
+    Construct a representation of array or block array shape and dtype
+    that is suitable for both jax arrays and scico blockarrays.
+
+    Args:
+       shape: Array or blockarray shape.
+       dtype: Array or blockarray dtype.
+
+    Returns:
+       A :class:`jax.ShapeDtypeStruct` or a :class:`.BlockArray`
+       containing :class:`jax.ShapeDtypeStruct`s.
+    """
+    if is_nested(shape):  # block array
+        return snp.BlockArray([jax.ShapeDtypeStruct(blk_shape, dtype=dtype) for blk_shape in shape])
+    else:  # standard array
+        return jax.ShapeDtypeStruct(shape, dtype=dtype)
+
+
 def broadcast_nested_shapes(
     shape_a: Union[Shape, BlockShape], shape_b: Union[Shape, BlockShape]
 ) -> Union[Shape, BlockShape]:

--- a/scico/numpy/util.py
+++ b/scico/numpy/util.py
@@ -413,7 +413,14 @@ def is_collapsible(shapes: Sequence[Union[Shape, BlockShape]]) -> bool:
     """Determine whether a sequence of shapes can be collapsed.
 
     Return ``True`` if the a list of shapes represent arrays that can
-    be stacked, i.e., they are all the same."""
+    be stacked, i.e., they are all the same.
+
+    Args:
+        shapes: A sequence of shapes.
+
+    Returns:
+        A boolean value indicating whether the shapes are all the same.
+    """
     return all(s == shapes[0] for s in shapes)
 
 
@@ -421,7 +428,14 @@ def is_blockable(shapes: Sequence[Union[Shape, BlockShape]]) -> TypeGuard[Union[
     """Determine whether a sequence of shapes could be a :class:`BlockArray` shape.
 
     Return ``True`` if the sequence of shapes represent arrays that can
-    be combined into a :class:`BlockArray`, i.e., none are nested."""
+    be combined into a :class:`BlockArray`, i.e., none are nested.
+
+    Args:
+        shapes: A sequence of shapes.
+
+    Returns:
+        A boolean value indicating whether any of the shapes are nested.
+    """
     return not any(is_nested(s) for s in shapes)
 
 

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -182,6 +182,21 @@ def test_sum_method(test_operator_obj, axis, keepdims):
     snp.testing.assert_allclose(method_result, snp_result)
 
 
+def test_eval_shape(test_operator_obj):
+    def foo(x, y):
+        return x * y
+
+    x = test_operator_obj.a
+    y = test_operator_obj.b
+
+    args = [
+        BlockArray([jax.ShapeDtypeStruct(b_i.shape, b_i.dtype) for b_i in x]),
+        BlockArray([jax.ShapeDtypeStruct(b_i.shape, b_i.dtype) for b_i in y]),
+    ]
+
+    jax.eval_shape(foo, *args)
+
+
 @pytest.mark.parametrize("operator", [snp.dot, snp.matmul])
 def test_ba_ba_dot(test_operator_obj, operator):
     a = test_operator_obj.a

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -12,6 +12,7 @@ import scico.numpy as snp
 from scico.numpy import BlockArray
 from scico.numpy._wrapped_function_lists import testing_functions
 from scico.numpy.testing import assert_array_equal
+from scico.numpy.util import shape_dtype_rep
 from scico.util import rgetattr
 
 math_ops = [op.add, op.sub, op.mul, op.truediv, op.pow]  # op.floordiv doesn't work on complex
@@ -200,12 +201,7 @@ def test_eval_shape_1arg(test_operator_obj):
         return snp.atleast_3d(x)
 
     x = test_operator_obj.a
-
-    args = [
-        BlockArray([jax.ShapeDtypeStruct(b_i.shape, b_i.dtype) for b_i in x]),
-    ]
-
-    es = jax.eval_shape(foo, *args)
+    es = jax.eval_shape(foo, shape_dtype_rep(x.shape, x.dtype))
     ba = foo(x)
     assert es.shape == ba.shape
     assert es.dtype == ba.dtype

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -207,7 +207,9 @@ def test_eval_shape(test_operator_obj):
         BlockArray([jax.ShapeDtypeStruct(b_i.shape, b_i.dtype) for b_i in y]),
     ]
 
-    jax.eval_shape(foo, *args)
+    es = jax.eval_shape(foo, *args)
+    assert es.shape == x.shape
+    assert es.dtype == x.dtype
 
 
 @pytest.mark.parametrize("operator", [snp.dot, snp.matmul])

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -195,7 +195,23 @@ def test_sum_method(test_operator_obj, axis, keepdims):
     sequence_assert_allclose(method_result, snp_result)
 
 
-def test_eval_shape(test_operator_obj):
+def test_eval_shape_1arg(test_operator_obj):
+    def foo(x):
+        return snp.atleast_3d(x)
+
+    x = test_operator_obj.a
+
+    args = [
+        BlockArray([jax.ShapeDtypeStruct(b_i.shape, b_i.dtype) for b_i in x]),
+    ]
+
+    es = jax.eval_shape(foo, *args)
+    ba = foo(x)
+    assert es.shape == ba.shape
+    assert es.dtype == ba.dtype
+
+
+def test_eval_shape_2arg(test_operator_obj):
     def foo(x, y):
         return x * y
 

--- a/scico/test/numpy/test_blockarray.py
+++ b/scico/test/numpy/test_blockarray.py
@@ -224,6 +224,14 @@ def test_eval_shape_2arg(test_operator_obj):
     assert es.dtype == x.dtype
 
 
+def test_linear_transpose(test_operator_obj):
+    fun = lambda x: 2 * x
+    x = test_operator_obj.a
+    tfun_ba = jax.linear_transpose(fun, x)
+    tfun_dts = jax.linear_transpose(fun, shape_dtype_rep(x.shape, x.dtype))
+    assert tfun_ba.args == tfun_dts.args
+
+
 @pytest.mark.parametrize("operator", [snp.dot, snp.matmul])
 def test_ba_ba_dot(test_operator_obj, operator):
     a = test_operator_obj.a

--- a/scico/test/numpy/test_numpy_util.py
+++ b/scico/test/numpy/test_numpy_util.py
@@ -24,6 +24,7 @@ from scico.numpy.util import (
     no_nan_divide,
     normalize_axes,
     real_dtype,
+    shape_dtype_rep,
     slice_length,
     transpose_list_of_ntpl,
     transpose_ntpl_of_list,
@@ -194,6 +195,12 @@ def test_is_blockable():
     shape2 = ((1, 2, 3), ((1, 2, 3), (1, 2, 3)))
     assert is_blockable(shape1)
     assert not is_blockable(shape2)
+
+
+@pytest.mark.parametrize("shape", [(3, 4), ((3, 4), (5,))])
+def test_shape_dtype_rep(shape):
+    dtype = np.float32
+    assert shape_dtype_rep(shape, dtype).shape == shape
 
 
 def test_is_real_dtype():


### PR DESCRIPTION
The purpose of this branch is to discover how `eval_shape` breaks with `BlockArray` arguments. Currently one test in `test_blockarray.py` shows the mechanism working, but we expect it will fail if `eval_shape` is used more widely.

Relates to #645.