### PR TITLE
Add `jax.numpy.pad` to list of wrapped functions

### DIFF
--- a/scico/numpy/_wrapped_function_lists.py
+++ b/scico/numpy/_wrapped_function_lists.py
@@ -235,6 +235,7 @@ mathematical_functions = (
     "resize",
     "trim_zeros",
     "unique",
+    "pad",
     "flip",
     "fliplr",
     "flipud",


### PR DESCRIPTION
Add `jax.numpy.pad` to list of functions wrapped in `scico.numpy`.