### PR TITLE
Improve `linop.xray.XRayTransform3D`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ SCICO Release Notes
 
 Version 0.0.8   (unreleased)
 ----------------------------
+
+• Substantial computational improvement in ``linop.xray.XRayTransform3D``,
+  which is now faster than ``linop.xray.astra.XRayTransform3D``.
 • Enable certain parameters of array creation functions to trigger
  ``BlockArray`` creation when they receive lists (currently ``device``).
 • New functional ``functional.BoxIndicator``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,7 @@ SCICO Release Notes
 Version 0.0.8   (unreleased)
 ----------------------------
 
-• Substantial computational improvement in ``linop.xray.XRayTransform3D``,
-  which is now faster than ``linop.xray.astra.XRayTransform3D``.
+• Computational improvement in ``linop.xray.XRayTransform3D``.
 • Enable certain parameters of array creation functions to trigger
   ``BlockArray`` creation when they receive lists (currently ``device``).
 • New interface to ASTRA Toolbox cone beam X-ray projectors.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -29,6 +29,7 @@ Computed Tomography
    examples/ct_astra_3d_tv_admm
    examples/ct_astra_3d_tv_padmm
    examples/ct_astra_3d_approx_tv_box_apgm
+   examples/ct_3d_tv_padmm
    examples/ct_tv_admm
    examples/ct_astra_tv_admm
    examples/ct_multi_tv_admm
@@ -149,6 +150,7 @@ Total Variation
    examples/ct_astra_3d_tv_admm
    examples/ct_astra_3d_tv_padmm
    examples/ct_astra_3d_approx_tv_box_apgm
+   examples/ct_3d_tv_padmm
    examples/ct_astra_weighted_tv_admm
    examples/ct_svmbir_tv_multi
    examples/deconv_circ_tv_admm
@@ -267,6 +269,7 @@ Proximal ADMM
    :maxdepth: 1
 
    examples/ct_astra_3d_tv_padmm
+   examples/ct_3d_tv_padmm
    examples/deconv_tv_padmm
    examples/denoise_tv_multi
    examples/deconv_ppp_dncnn_padmm

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -26,9 +26,9 @@ Computed Tomography
    examples/ct_abel_tv_admm_tune
    examples/ct_symcone_tv_padmm
    examples/ct_astra_noreg_pcg
+   examples/ct_astra_3d_approx_tv_box_apgm
    examples/ct_astra_3d_tv_admm
    examples/ct_astra_3d_tv_padmm
-   examples/ct_astra_3d_approx_tv_box_apgm
    examples/ct_3d_tv_padmm
    examples/ct_tv_admm
    examples/ct_astra_tv_admm
@@ -148,8 +148,8 @@ Total Variation
    examples/ct_multi_tv_admm
    examples/ct_astra_tv_admm
    examples/ct_astra_3d_tv_admm
-   examples/ct_astra_3d_tv_padmm
    examples/ct_astra_3d_approx_tv_box_apgm
+   examples/ct_astra_3d_tv_padmm
    examples/ct_3d_tv_padmm
    examples/ct_astra_weighted_tv_admm
    examples/ct_svmbir_tv_multi

--- a/examples/scripts/README.rst
+++ b/examples/scripts/README.rst
@@ -17,14 +17,14 @@ Computed Tomography
       TV-Regularized Cone Beam CT for Symmetric Objects
    `ct_astra_noreg_pcg.py <ct_astra_noreg_pcg.py>`_
       CT Reconstruction with CG and PCG
+   `ct_astra_3d_approx_tv_box_apgm.py <ct_astra_3d_approx_tv_box_apgm.py>`_
+      3D TV-Regularized Sparse-View CT Reconstruction (APGM Solver, Sharded)
    `ct_astra_3d_tv_admm.py <ct_astra_3d_tv_admm.py>`_
       3D TV-Regularized Sparse-View CT Reconstruction (ADMM Solver)
    `ct_astra_3d_tv_padmm.py <ct_astra_3d_tv_padmm.py>`_
-      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
-   `ct_astra_3d_approx_tv_box_apgm.py <ct_astra_3d_approx_tv_box_apgm.py>`_
-      3D TV-Regularized Sparse-View CT Reconstruction (APGM Solver, Sharded)
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, ASTRA Projector)
    `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
-      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, SCICO Projector)
    `ct_tv_admm.py <ct_tv_admm.py>`_
       TV-Regularized Sparse-View CT Reconstruction (Integrated Projector)
    `ct_astra_tv_admm.py <ct_astra_tv_admm.py>`_
@@ -187,12 +187,12 @@ Total Variation
       TV-Regularized Sparse-View CT Reconstruction (ASTRA Projector)
    `ct_astra_3d_tv_admm.py <ct_astra_3d_tv_admm.py>`_
       3D TV-Regularized Sparse-View CT Reconstruction (ADMM Solver)
-   `ct_astra_3d_tv_padmm.py <ct_astra_3d_tv_padmm.py>`_
-      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
    `ct_astra_3d_approx_tv_box_apgm.py <ct_astra_3d_approx_tv_box_apgm.py>`_
       3D TV-Regularized Sparse-View CT Reconstruction (APGM Solver, Sharded)
+   `ct_astra_3d_tv_padmm.py <ct_astra_3d_tv_padmm.py>`_
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, ASTRA Projector)
    `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
-      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, SCICO Projector)
    `ct_astra_weighted_tv_admm.py <ct_astra_weighted_tv_admm.py>`_
       TV-Regularized Low-Dose CT Reconstruction
    `ct_svmbir_tv_multi.py <ct_svmbir_tv_multi.py>`_
@@ -363,9 +363,9 @@ Proximal ADMM
 ^^^^^^^^^^^^^
 
     `ct_astra_3d_tv_padmm.py <ct_astra_3d_tv_padmm.py>`_
-       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, ASTRA Projector)
     `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
-       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, SCICO Projector)
     `deconv_tv_padmm.py <deconv_tv_padmm.py>`_
        Image Deconvolution with TV Regularization (Proximal ADMM Solver)
     `denoise_tv_multi.py <denoise_tv_multi.py>`_

--- a/examples/scripts/README.rst
+++ b/examples/scripts/README.rst
@@ -23,6 +23,8 @@ Computed Tomography
       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
    `ct_astra_3d_approx_tv_box_apgm.py <ct_astra_3d_approx_tv_box_apgm.py>`_
       3D TV-Regularized Sparse-View CT Reconstruction (APGM Solver, Sharded)
+   `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
    `ct_tv_admm.py <ct_tv_admm.py>`_
       TV-Regularized Sparse-View CT Reconstruction (Integrated Projector)
    `ct_astra_tv_admm.py <ct_astra_tv_admm.py>`_
@@ -189,6 +191,8 @@ Total Variation
       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
    `ct_astra_3d_approx_tv_box_apgm.py <ct_astra_3d_approx_tv_box_apgm.py>`_
       3D TV-Regularized Sparse-View CT Reconstruction (APGM Solver, Sharded)
+   `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
+      3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
    `ct_astra_weighted_tv_admm.py <ct_astra_weighted_tv_admm.py>`_
       TV-Regularized Low-Dose CT Reconstruction
    `ct_svmbir_tv_multi.py <ct_svmbir_tv_multi.py>`_
@@ -359,6 +363,8 @@ Proximal ADMM
 ^^^^^^^^^^^^^
 
     `ct_astra_3d_tv_padmm.py <ct_astra_3d_tv_padmm.py>`_
+       3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+    `ct_3d_tv_padmm.py <ct_3d_tv_padmm.py>`_
        3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
     `deconv_tv_padmm.py <deconv_tv_padmm.py>`_
        Image Deconvolution with TV Regularization (Proximal ADMM Solver)

--- a/examples/scripts/ct_3d_tv_padmm.py
+++ b/examples/scripts/ct_3d_tv_padmm.py
@@ -25,10 +25,11 @@ This example uses the native scico 3d X-Ray projector, while the
 
 import numpy as np
 
+import komplot as kplt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 import scico.numpy as snp
-from scico import functional, linop, loss, metric, plot
+from scico import functional, linop, loss, metric
 from scico.examples import create_tangle_phantom
 from scico.linop.xray import XRayTransform3D
 from scico.linop.xray.astra import angle_to_vector, convert_to_scico_geometry
@@ -131,28 +132,56 @@ print(
 
 
 """
-Show the recovered image.
+Show the recovered volume.
 """
-fig, ax = plot.subplots(nrows=1, ncols=2, figsize=(7, 6))
-plot.imview(
+fig, ax = kplt.subplots(nrows=1, ncols=2, sharex=True, sharey=True, figsize=(7, 6))
+kplt.imview(
     tangle[32],
-    title="Ground truth (central slice)",
-    cmap=plot.cm.Blues,
-    cbar=None,
-    fig=fig,
+    title="Ground truth",
+    cmap=kplt.cm.viridis,
+    show_cbar=None,
     ax=ax[0],
 )
-plot.imview(
+kplt.imview(
     tangle_recon[32],
-    title="TV Reconstruction (central slice)\nSNR: %.2f (dB), MAE: %.3f"
+    title="TV Reconstruction\nSNR: %.2f (dB), MAE: %.3f"
     % (metric.snr(tangle, tangle_recon), metric.mae(tangle, tangle_recon)),
-    cmap=plot.cm.Blues,
-    fig=fig,
+    cmap=kplt.cm.viridis,
     ax=ax[1],
 )
 divider = make_axes_locatable(ax[1])
 cax = divider.append_axes("right", size="5%", pad=0.2)
 fig.colorbar(ax[1].get_images()[0], cax=cax, label="arbitrary units")
+fig.suptitle("Central slice on $z$ axis (axis 0)")
+fig.tight_layout()
+fig.show()
+
+fig, ax = kplt.subplots(
+    nrows=1,
+    ncols=2,
+    sharex=True,
+    sharey=True,
+    gridspec_kw={"width_ratios": [1, 1.08]},
+    figsize=(13, 4),
+)
+kplt.imview(
+    tangle[:, 128],
+    title="Ground truth",
+    cmap=kplt.cm.viridis,
+    ax=ax[0],
+)
+kplt.imview(
+    tangle_recon[:, 128],
+    title="TV Reconstruction\nSNR: %.2f (dB), MAE: %.3f"
+    % (metric.snr(tangle, tangle_recon), metric.mae(tangle, tangle_recon)),
+    cmap=kplt.cm.viridis,
+    ax=ax[1],
+)
+divider = make_axes_locatable(ax[1])
+cax = divider.append_axes("right", size="5%", pad=0.2)
+fig.colorbar(ax[1].get_images()[0], ax=ax[1], cax=cax, label="arbitrary units")
+fig.suptitle("Central slice on $y$ axis (axis 1)")
+fig.tight_layout()
 fig.show()
 
 input("\nWaiting for input to close figures and exit")

--- a/examples/scripts/ct_3d_tv_padmm.py
+++ b/examples/scripts/ct_3d_tv_padmm.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of the SCICO package. Details of the copyright
+# and user license can be found in the 'LICENSE.txt' file distributed
+# with the package.
+
+r"""
+3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
+======================================================================
+
+This example demonstrates solution of a sparse-view, 3D CT
+reconstruction problem with isotropic total variation (TV)
+regularization
+
+  $$\mathrm{argmin}_{\mathbf{x}} \; (1/2) \| \mathbf{y} - C \mathbf{x}
+  \|_2^2 + \lambda \| D \mathbf{x} \|_{2,1} \;,$$
+
+where $C$ is the X-ray transform (the CT forward projection operator),
+$\mathbf{y}$ is the sinogram, $D$ is a 3D finite difference operator,
+and $\mathbf{x}$ is the reconstructed image.
+
+This example uses the native scico 3d X-Ray projector, while the
+[companion example](ct_astra_3d_tv_padmm.rst) uses the astra projector.
+"""
+
+import numpy as np
+
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+import scico.numpy as snp
+from scico import functional, linop, loss, metric, plot
+from scico.examples import create_tangle_phantom
+from scico.linop.xray import XRayTransform3D
+from scico.linop.xray.astra import angle_to_vector, convert_to_scico_geometry
+from scico.optimize import ProximalADMM
+from scico.util import device_info
+
+"""
+Create a ground truth image and projector.
+"""
+Nx = 128
+Ny = 256
+Nz = 64
+
+tangle = snp.array(create_tangle_phantom(Nx, Ny, Nz))
+
+n_projection = 10  # number of projections
+angles = np.linspace(0, np.pi, n_projection, endpoint=False)  # evenly spaced projection angles
+det_spacing = [1.0, 1.0]
+det_count = (Nz, max(Nx, Ny))
+vectors = angle_to_vector(det_spacing, angles)
+
+# It would have been more straightforward to use the det_spacing and angles keywords
+# in this case (since vectors is just computed directly from these two quantities), but
+# the more general form is used here as a demonstration.
+matrices = convert_to_scico_geometry(input_shape=tangle.shape, det_count=det_count, vectors=vectors)
+C = XRayTransform3D(tangle.shape, matrices, det_count)  # CT projection operator
+y = C @ tangle  # sinogram
+
+
+r"""
+Set up problem and solver. We want to minimize the functional
+
+  $$\mathrm{argmin}_{\mathbf{x}} \; (1/2) \| \mathbf{y} - C \mathbf{x}
+  \|_2^2 + \lambda \| D \mathbf{x} \|_{2,1} \;,$$
+
+where $C$ is the X-ray transform and $D$ is a finite difference
+operator. This problem can be expressed as
+
+  $$\mathrm{argmin}_{\mathbf{x}, \mathbf{z}} \; (1/2) \| \mathbf{y} -
+  \mathbf{z}_0 \|_2^2 + \lambda \| \mathbf{z}_1 \|_{2,1} \;\;
+  \text{such that} \;\; \mathbf{z}_0 = C \mathbf{x} \;\; \text{and} \;\;
+  \mathbf{z}_1 = D \mathbf{x} \;,$$
+
+which can be written in the form of a standard ADMM problem
+
+  $$\mathrm{argmin}_{\mathbf{x}, \mathbf{z}} \; f(\mathbf{x}) + g(\mathbf{z})
+  \;\; \text{such that} \;\; A \mathbf{x} + B \mathbf{z} = \mathbf{c}$$
+
+with
+
+  $$f = 0 \qquad g = g_0 + g_1$$
+  $$g_0(\mathbf{z}_0) = (1/2) \| \mathbf{y} - \mathbf{z}_0 \|_2^2 \qquad
+  g_1(\mathbf{z}_1) = \lambda \| \mathbf{z}_1 \|_{2,1}$$
+  $$A = \left( \begin{array}{c} C \\ D \end{array} \right) \qquad
+  B = \left( \begin{array}{cc} -I & 0 \\ 0 & -I \end{array} \right) \qquad
+  \mathbf{c} = \left( \begin{array}{c} 0 \\ 0 \end{array} \right) \;.$$
+
+This is a more complex splitting than that used in the
+[companion example](ct_astra_3d_tv_admm.rst), but it allows the use of a
+proximal ADMM solver in a way that avoids the need for the conjugate
+gradient sub-iterations used by the ADMM solver in the
+[companion example](ct_astra_3d_tv_admm.rst).
+"""
+𝛼 = 1e2  # improve problem conditioning by balancing C and D components of A
+λ = 2e0  # ℓ2,1 norm regularization parameter
+ρ = 5e-3  # ADMM penalty parameter
+maxiter = 1000  # number of ADMM iterations
+
+f = functional.ZeroFunctional()
+g0 = loss.SquaredL2Loss(y=y)
+g1 = (λ / 𝛼) * functional.L21Norm()
+g = functional.SeparableFunctional((g0, g1))
+D = linop.FiniteDifference(input_shape=tangle.shape, append=0)
+
+A = linop.VerticalStack((C, 𝛼 * D))
+mu, nu = ProximalADMM.estimate_parameters(A)
+
+solver = ProximalADMM(
+    f=f,
+    g=g,
+    A=A,
+    B=None,
+    rho=ρ,
+    mu=mu,
+    nu=nu,
+    maxiter=maxiter,
+    itstat_options={"display": True, "period": 50},
+)
+
+"""
+Run the solver.
+"""
+print(f"Solving on {device_info()}\n")
+tangle_recon = solver.solve()
+
+print(
+    "TV Restruction\nSNR: %.2f (dB), MAE: %.3f"
+    % (metric.snr(tangle, tangle_recon), metric.mae(tangle, tangle_recon))
+)
+
+
+"""
+Show the recovered image.
+"""
+fig, ax = plot.subplots(nrows=1, ncols=2, figsize=(7, 6))
+plot.imview(
+    tangle[32],
+    title="Ground truth (central slice)",
+    cmap=plot.cm.Blues,
+    cbar=None,
+    fig=fig,
+    ax=ax[0],
+)
+plot.imview(
+    tangle_recon[32],
+    title="TV Reconstruction (central slice)\nSNR: %.2f (dB), MAE: %.3f"
+    % (metric.snr(tangle, tangle_recon), metric.mae(tangle, tangle_recon)),
+    cmap=plot.cm.Blues,
+    fig=fig,
+    ax=ax[1],
+)
+divider = make_axes_locatable(ax[1])
+cax = divider.append_axes("right", size="5%", pad=0.2)
+fig.colorbar(ax[1].get_images()[0], cax=cax, label="arbitrary units")
+fig.show()
+
+input("\nWaiting for input to close figures and exit")

--- a/examples/scripts/ct_3d_tv_padmm.py
+++ b/examples/scripts/ct_3d_tv_padmm.py
@@ -5,8 +5,8 @@
 # with the package.
 
 r"""
-3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
-======================================================================
+3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, SCICO Projector)
+=======================================================================================
 
 This example demonstrates solution of a sparse-view, 3D CT
 reconstruction problem with isotropic total variation (TV)

--- a/examples/scripts/ct_astra_3d_tv_padmm.py
+++ b/examples/scripts/ct_astra_3d_tv_padmm.py
@@ -47,7 +47,7 @@ tangle = snp.array(create_tangle_phantom(Nx, Ny, Nz))
 n_projection = 10  # number of projections
 angles = np.linspace(0, np.pi, n_projection, endpoint=False)  # evenly spaced projection angles
 det_spacing = [1.0, 1.0]
-det_count = [Nz, max(Nx, Ny)]
+det_count = (Nz, max(Nx, Ny))
 vectors = angle_to_vector(det_spacing, angles)
 
 # It would have been more straightforward to use the det_spacing and angles keywords

--- a/examples/scripts/ct_astra_3d_tv_padmm.py
+++ b/examples/scripts/ct_astra_3d_tv_padmm.py
@@ -5,8 +5,8 @@
 # with the package.
 
 r"""
-3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver)
-======================================================================
+3D TV-Regularized Sparse-View CT Reconstruction (Proximal ADMM Solver, ASTRA Projector)
+=======================================================================================
 
 This example demonstrates solution of a sparse-view, 3D CT
 reconstruction problem with isotropic total variation (TV)

--- a/examples/scripts/ct_projector_comparison_3d.py
+++ b/examples/scripts/ct_projector_comparison_3d.py
@@ -43,13 +43,13 @@ Set up SCICO projection.
 """
 num_angles = 3
 
-
 rot_X = 90.0 - 16.0
 rot_Y = np.linspace(0, 180, num_angles, endpoint=False)
 angles = np.stack(np.broadcast_arrays(rot_X, rot_Y), axis=-1)
 matrices = XRayTransform3D.matrices_from_euler_angles(
     in_shape, out_shape, "XY", angles, degrees=True
 )
+
 
 """
 Specify geometry using SCICO conventions and project.
@@ -83,7 +83,6 @@ timer_scico.td["avg_back"] /= num_repeats
 """
 Convert SCICO geometry to ASTRA and project.
 """
-
 vectors_from_scico = astra.convert_from_scico_geometry(in_shape, matrices, out_shape)
 
 timer_astra = Timer()
@@ -115,7 +114,6 @@ timer_astra.td["avg_back"] /= num_repeats
 """
 Specify geometry with ASTRA conventions and project.
 """
-
 angles = np.random.rand(num_angles) * 180  # random projection angles
 det_spacing = [1.0, 1.0]
 vectors = astra.angle_to_vector(det_spacing, angles)
@@ -129,7 +127,6 @@ HTy_astra = H_astra.T @ y_astra
 """
 Convert ASTRA geometry to SCICO and project.
 """
-
 P_from_astra = astra._astra_to_scico_geometry(H_astra.vol_geom, H_astra.proj_geom)
 H_scico_from_astra = XRayTransform3D(in_shape, P_from_astra, out_shape)
 
@@ -140,6 +137,10 @@ HTy_scico_from_astra = H_scico_from_astra.T @ y_scico_from_astra
 """
 Print timing results.
 """
+print(
+    "X-ray projector timing comparison:\n"
+    f"    astra vs scico, {num_angles} views of a {" x ".join(map(str,in_shape))} volume"
+)
 print(f"init         astra    {timer_astra.td['init']:.2e} s")
 print(f"init         scico    {timer_scico.td['init']:.2e} s")
 print("")

--- a/examples/scripts/ct_projector_comparison_3d.py
+++ b/examples/scripts/ct_projector_comparison_3d.py
@@ -28,7 +28,7 @@ from scico.util import ContextTimer, Timer
 """
 Create a ground truth image and set detector dimensions.
 """
-N = 64
+N = 128
 # use rectangular volume to check whether axes are handled correctly
 in_shape = (N + 1, N + 2, N + 3)
 x = create_block_phantom(in_shape)

--- a/examples/scripts/index.rst
+++ b/examples/scripts/index.rst
@@ -15,6 +15,7 @@ Computed Tomography
    - ct_astra_noreg_pcg.py
    - ct_astra_3d_tv_admm.py
    - ct_astra_3d_tv_padmm.py
+   - ct_3d_tv_padmm.py
    - ct_tv_admm.py
    - ct_astra_tv_admm.py
    - ct_multi_tv_admm.py
@@ -112,6 +113,7 @@ Total Variation
    - ct_astra_tv_admm.py
    - ct_astra_3d_tv_admm.py
    - ct_astra_3d_tv_padmm.py
+   - ct_3d_tv_padmm.py
    - ct_astra_weighted_tv_admm.py
    - ct_svmbir_tv_multi.py
    - deconv_circ_tv_admm.py
@@ -210,6 +212,7 @@ Proximal ADMM
 ^^^^^^^^^^^^^
 
     - ct_astra_3d_tv_padmm.py
+    - ct_3d_tv_padmm.py
     - deconv_tv_padmm.py
     - denoise_tv_multi.py
     - deconv_ppp_dncnn_padmm.py

--- a/examples/scripts/index.rst
+++ b/examples/scripts/index.rst
@@ -13,9 +13,9 @@ Computed Tomography
    - ct_abel_tv_admm_tune.py
    - ct_symcone_tv_padmm.py
    - ct_astra_noreg_pcg.py
+   - ct_astra_3d_approx_tv_box_apgm.py
    - ct_astra_3d_tv_admm.py
    - ct_astra_3d_tv_padmm.py
-   - ct_astra_3d_approx_tv_box_apgm.py
    - ct_3d_tv_padmm.py
    - ct_tv_admm.py
    - ct_astra_tv_admm.py
@@ -114,8 +114,8 @@ Total Variation
    - ct_multi_tv_admm.py
    - ct_astra_tv_admm.py
    - ct_astra_3d_tv_admm.py
-   - ct_astra_3d_tv_padmm.py
    - ct_astra_3d_approx_tv_box_apgm.py
+   - ct_astra_3d_tv_padmm.py
    - ct_3d_tv_padmm.py
    - ct_astra_weighted_tv_admm.py
    - ct_svmbir_tv_multi.py

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -368,7 +368,7 @@ class XRayTransform3D(LinearOperator):
 
         self.input_shape: Shape = input_shape
         self.matrices = jnp.asarray(matrices, dtype=np.float32)
-        self.det_shape = det_shape
+        self.det_shape = tuple(det_shape)  # in case det_shape is a list
         self.output_shape = (len(matrices), *det_shape)
         super().__init__(
             input_shape=input_shape,

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -400,7 +400,7 @@ class XRayTransform3D(LinearOperator):
         MAX_SLICE_LEN = 10
         slice_offsets = list(range(0, im.shape[0], MAX_SLICE_LEN))
 
-        blank_view_plane = jnp.zeros(det_shape, dtype=im.dtype)
+        view_plane = jnp.zeros(det_shape, dtype=im.dtype)
 
         def project_single_matrix(matrix, init_plane):
             proj_plane = init_plane
@@ -415,10 +415,9 @@ class XRayTransform3D(LinearOperator):
 
         mapped_project = jax.vmap(project_single_matrix, in_axes=(0, None))
 
-        return mapped_project(matrices, blank_view_plane)
+        return mapped_project(matrices, view_plane)
 
     @staticmethod
-    # @partial(jax.jit, donate_argnames="proj")
     def _project_single(
         im: ArrayLike, matrix: ArrayLike, proj: ArrayLike, slice_offset: int = 0
     ) -> snp.Array:
@@ -450,14 +449,14 @@ class XRayTransform3D(LinearOperator):
         MAX_SLICE_LEN = 10
         slice_offsets = list(range(0, input_shape[0], MAX_SLICE_LEN))
 
-        # 1. Provide an accumulator buffer matching the inner target slice size
+        # Provide an accumulator buffer matching the inner target slice size
         # This acts as the tracer buffer, preventing 'donated buffer' mismatches.
-        blank_im_slice_buffer = jnp.zeros((MAX_SLICE_LEN,) + input_shape[1:], dtype=proj.dtype)
+        im_slice_buffer = jnp.zeros((MAX_SLICE_LEN,) + input_shape[1:], dtype=proj.dtype)
 
-        # 2. Extract specific image slices across ALL views simultaneously
+        # Extract specific image slices across ALL views simultaneously
         def back_project_single_slice(slice_offset):
             # We start with our empty, statically shaped sub-slice buffer
-            im_slice = blank_im_slice_buffer
+            im_slice = im_slice_buffer
 
             # Sequentially accumulate contributions from all projection views into this slice
             for view_ind, matrix in enumerate(matrices):
@@ -469,19 +468,18 @@ class XRayTransform3D(LinearOperator):
                 )
             return im_slice
 
-        # 3. Use vmap to calculate all slice blocks in parallel
+        # Use vmap to calculate all slice blocks in parallel.
         mapped_back_project = jax.vmap(back_project_single_slice)
         all_slices = mapped_back_project(jnp.array(slice_offsets))
 
-        # 4. Reshape the stacked vmap output back into a continuous 3D image array
-        # vmap gives (num_slices, MAX_SLICE_LEN, Y, Z), we flatten the first two axes
+        # Reshape the stacked vmap output back into a continuous 3D image array
+        # vmap gives (num_slices, MAX_SLICE_LEN, Y, Z), we flatten the first two axes.
         im = all_slices.reshape((-1,) + input_shape[1:])
 
-        # Trim any padding if the image size isn't perfectly divisible by MAX_SLICE_LEN
+        # Trim any padding if the image size isn't perfectly divisible by MAX_SLICE_LEN.
         return im[: input_shape[0]]
 
     @staticmethod
-    # @partial(jax.jit, donate_argnames="HTy")
     def _back_project_single(
         y: ArrayLike, matrix: ArrayLike, HTy: ArrayLike, slice_offset: int = 0
     ) -> snp.Array:

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -400,8 +400,12 @@ class XRayTransform3D(LinearOperator):
         MAX_SLICE_LEN = 10
         slice_offsets = list(range(0, im.shape[0], MAX_SLICE_LEN))
 
+        # Provide an accumulator buffer matching the inner target detector size
+        # to avoid tracer buffer mismatch warnings during vmap tracing.
         view_plane = jnp.zeros(det_shape, dtype=im.dtype)
 
+        # Compute complete projections across all slice blocks for a single view
+        # matrix.
         def project_single_matrix(matrix, init_plane):
             proj_plane = init_plane
             for slice_offset in slice_offsets:
@@ -413,6 +417,7 @@ class XRayTransform3D(LinearOperator):
                 )
             return proj_plane
 
+        # Use vmap to process all projection views in parallel
         mapped_project = jax.vmap(project_single_matrix, in_axes=(0, None))
 
         return mapped_project(matrices, view_plane)

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -397,30 +397,28 @@ class XRayTransform3D(LinearOperator):
                 matrices.
             det_shape: Shape of detector.
         """
-        MAX_SLICE_LEN = 10
-        slice_offsets = list(range(0, im.shape[0], MAX_SLICE_LEN))
+        BATCH_SIZE = 10
 
-        # Provide an accumulator buffer matching the inner target detector size
-        # to avoid tracer buffer mismatch warnings during vmap tracing.
-        view_plane = jnp.zeros(det_shape, dtype=im.dtype)
+        # Apply gradient checkpointing to the underlying core operator
+        project_single = jax.remat(XRayTransform3D._project_single)
 
-        # Compute complete projections across all slice blocks for a single view
-        # matrix.
-        def project_single_matrix(matrix, init_plane):
-            proj_plane = init_plane
-            for slice_offset in slice_offsets:
-                proj_plane = XRayTransform3D._project_single(
-                    im[slice_offset : slice_offset + MAX_SLICE_LEN],
-                    matrix,
-                    proj_plane,
-                    slice_offset=slice_offset,
-                )
-            return proj_plane
+        # Define projection behavior for a single matrix over the full image
+        def project_single_matrix(matrix):
+            # Start with an empty detector plane baseline
+            init_plane = jnp.zeros(det_shape, dtype=im.dtype)
 
-        # Use vmap to process all projection views in parallel
-        mapped_project = jax.vmap(project_single_matrix, in_axes=(0, None))
+            # Call the rematerialized operator on the full image
+            return XRayTransform3D._project_single(
+                im,
+                matrix,
+                init_plane,
+                slice_offset=0,  # No manual loops: processed as a whole
+            )
 
-        return mapped_project(matrices, view_plane)
+        # Automatically chunk and execute views sequentially/parallelized via JAX.
+        # If len(matrices) is not divisible by BATCH_SIZE, JAX natively handles the
+        # remainder.
+        return jax.lax.map(project_single_matrix, matrices, batch_size=BATCH_SIZE)
 
     @staticmethod
     def _project_single(
@@ -451,38 +449,35 @@ class XRayTransform3D(LinearOperator):
             matrix: (num_views, 2, 4) array of homogeneous projection matrices.
             input_shape: Shape of back projection.
         """
-        MAX_SLICE_LEN = 10
-        slice_offsets = list(range(0, input_shape[0], MAX_SLICE_LEN))
+        BATCH_SIZE = 10
 
-        # Provide an accumulator buffer matching the inner target slice size
-        # This acts as the tracer buffer, preventing 'donated buffer' mismatches.
-        im_slice_buffer = jnp.zeros((MAX_SLICE_LEN,) + input_shape[1:], dtype=proj.dtype)
+        # Wrap the single back-project function for gradient checkpointing
+        back_project_single_core = jax.remat(XRayTransform3D._back_project_single)
 
-        # Extract specific image slices across all views simultaneously
-        def back_project_single_slice(slice_offset):
-            # We start with our empty, statically shaped sub-slice buffer
-            im_slice = im_slice_buffer
+        # Process an individual view slice-by-slice natively via map mapping
+        def back_project_single_view(packed_inputs):
+            # Unpack the active iteration variables provided by lax.map
+            single_proj, single_matrix = packed_inputs
 
-            # Sequentially accumulate contributions from all projection views into this slice
-            for view_ind, matrix in enumerate(matrices):
-                im_slice = XRayTransform3D._back_project_single(
-                    proj[view_ind],
-                    matrix,
-                    im_slice,
-                    slice_offset=slice_offset,
-                )
-            return im_slice
+            # Initialize a full-sized target volume structure for this single projection contribution
+            init_volume = jnp.zeros(input_shape, dtype=proj.dtype)
 
-        # Use vmap to calculate all slice blocks in parallel.
-        mapped_back_project = jax.vmap(back_project_single_slice)
-        all_slices = mapped_back_project(jnp.array(slice_offsets))
+            return back_project_single_core(
+                single_proj,
+                single_matrix,
+                init_volume,
+                slice_offset=0,  # Let JAX optimize the internal execution structure
+            )
 
-        # Reshape the stacked vmap output back into a continuous 3D image array
-        # vmap gives (num_slices, MAX_SLICE_LEN, Y, Z), we flatten the first two axes.
-        im = all_slices.reshape((-1,) + input_shape[1:])
+        # Map across the zip-like structure of projections and matrices.
+        # lax.map accumulates a stacked array of individual volume reconstructions.
+        individual_volumes = jax.lax.map(
+            back_project_single_view, (proj, matrices), batch_size=BATCH_SIZE
+        )
 
-        # Trim any padding if the image size isn't perfectly divisible by MAX_SLICE_LEN.
-        return im[: input_shape[0]]
+        # Collapse the mapped axis by summing the independent view contributions
+        # to finalize the reconstructed 3D output image array.
+        return jnp.sum(individual_volumes, axis=0)
 
     @staticmethod
     def _back_project_single(

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -458,7 +458,7 @@ class XRayTransform3D(LinearOperator):
         # This acts as the tracer buffer, preventing 'donated buffer' mismatches.
         im_slice_buffer = jnp.zeros((MAX_SLICE_LEN,) + input_shape[1:], dtype=proj.dtype)
 
-        # Extract specific image slices across ALL views simultaneously
+        # Extract specific image slices across all views simultaneously
         def back_project_single_slice(slice_offset):
             # We start with our empty, statically shaped sub-slice buffer
             im_slice = im_slice_buffer

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -408,7 +408,7 @@ class XRayTransform3D(LinearOperator):
             init_plane = jnp.zeros(det_shape, dtype=im.dtype)
 
             # Call the rematerialized operator on the full image
-            return XRayTransform3D._project_single(
+            return project_single(
                 im,
                 matrix,
                 init_plane,
@@ -452,17 +452,18 @@ class XRayTransform3D(LinearOperator):
         BATCH_SIZE = 10
 
         # Wrap the single back-project function for gradient checkpointing
-        back_project_single_core = jax.remat(XRayTransform3D._back_project_single)
+        back_project_single = jax.remat(XRayTransform3D._back_project_single)
 
         # Process an individual view slice-by-slice natively via map mapping
         def back_project_single_view(packed_inputs):
             # Unpack the active iteration variables provided by lax.map
             single_proj, single_matrix = packed_inputs
 
-            # Initialize a full-sized target volume structure for this single projection contribution
+            # Initialize a full-sized target volume structure for this single projection
+            # contribution
             init_volume = jnp.zeros(input_shape, dtype=proj.dtype)
 
-            return back_project_single_core(
+            return back_project_single(
                 single_proj,
                 single_matrix,
                 init_volume,

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -328,9 +328,6 @@ class XRayTransform3D(LinearOperator):
     adjoint of the forward projector. It is written purely in JAX,
     allowing it to run on either CPU or GPU and minimizing host copies.
 
-    Warning: This class is experimental and may be up to ten times slower
-    than :class:`scico.linop.xray.astra.XRayTransform3D`.
-
     For each view, the projection geometry is specified by an array
     with shape (2, 4) that specifies a :math:`2 \times 3` projection
     matrix and a :math:`2 \times 1` offset vector. Denoting the matrix

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2023-2024 by SCICO Developers
+# Copyright (C) 2023-2026 by SCICO Developers
 # All rights reserved. BSD 3-clause License.
 # This file is part of the SCICO package. Details of the copyright and
 # user license can be found in the 'LICENSE' file distributed with the
@@ -19,7 +19,7 @@ from jax.typing import ArrayLike
 
 import scico.numpy as snp
 from scico.numpy.util import is_scalar_equiv
-from scico.typing import Shape
+from scico.typing import DType, Shape
 from scipy.spatial.transform import Rotation
 
 from .._linop import LinearOperator
@@ -334,8 +334,9 @@ class XRayTransform3D(LinearOperator):
     For each view, the projection geometry is specified by an array
     with shape (2, 4) that specifies a :math:`2 \times 3` projection
     matrix and a :math:`2 \times 1` offset vector. Denoting the matrix
-    by :math:`\mathbf{M}` and the offset by :math:`\mathbf{t}`, a voxel at array
-    index `(i, j, k)` has its center projected to the detector coordinates
+    by :math:`\mathbf{M}` and the offset by :math:`\mathbf{t}`, a voxel
+    at array index `(i, j, k)` has its center projected to the detector
+    coordinates
 
     .. math::
         \mathbf{M} \begin{bmatrix}
@@ -354,12 +355,15 @@ class XRayTransform3D(LinearOperator):
         input_shape: Shape,
         matrices: ArrayLike,
         det_shape: Shape,
+        input_dtype: DType = np.float32,
     ):
         r"""
         Args:
-            input_shape: Shape of input image.
-            matrices: (num_views, 2, 4) array of homogeneous projection matrices.
+            input_shape: Input array shape.
+            matrices: (num_views, 2, 4) array of homogeneous projection
+               matrices.
             det_shape: Shape of detector.
+            input_dtype: Input array dtype.
         """
 
         self.input_shape: Shape = input_shape
@@ -371,6 +375,8 @@ class XRayTransform3D(LinearOperator):
             output_shape=self.output_shape,
             eval_fn=self.project,
             adj_fn=self.back_project,
+            input_dtype=input_dtype,
+            output_dtype=input_dtype,
         )
 
     def project(self, im: ArrayLike) -> snp.Array:
@@ -386,7 +392,8 @@ class XRayTransform3D(LinearOperator):
         r"""
         Args:
             im: Input image.
-            matrix: (num_views, 2, 4) array of homogeneous projection matrices.
+            matrix: (num_views, 2, 4) array of homogeneous projection
+                matrices.
             det_shape: Shape of detector.
         """
         MAX_SLICE_LEN = 10
@@ -547,11 +554,14 @@ class XRayTransform3D(LinearOperator):
         Args:
             input_shape: Shape of input image.
             output_shape: Shape of output (detector).
-            str: Sequence of axes for rotation. Up to 3 characters belonging to the set {'X', 'Y', 'Z'}
-                for intrinsic rotations, or {'x', 'y', 'z'} for extrinsic rotations. Extrinsic and
-                intrinsic rotations cannot be mixed in one function call.
+            str: Sequence of axes for rotation. Up to 3 characters
+                belonging to the set {'X', 'Y', 'Z'} for intrinsic
+                rotations, or {'x', 'y', 'z'} for extrinsic rotations.
+                Extrinsic and intrinsic rotations cannot be mixed in one
+                function call.
             angles: (num_views, N), N = 1, 2, or 3 Euler angles.
-            degrees: If ``True``, angles are in degrees, otherwise radians. Default: ``True``, radians.
+            degrees: If ``True``, angles are in degrees, otherwise
+                radians. Default: ``True``, radians.
             voxel_spacing: (3,) array giving the spacing of image
                 voxels.  Default: `[1.0, 1.0, 1.0]`. Experimental.
             det_spacing: (2,) array giving the spacing of detector

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -397,7 +397,7 @@ class XRayTransform3D(LinearOperator):
                 matrices.
             det_shape: Shape of detector.
         """
-        BATCH_SIZE = 10
+        BATCH_SIZE = 8
 
         # Apply gradient checkpointing to the underlying core operator
         project_single = jax.remat(XRayTransform3D._project_single)
@@ -449,7 +449,7 @@ class XRayTransform3D(LinearOperator):
             matrix: (num_views, 2, 4) array of homogeneous projection matrices.
             input_shape: Shape of back projection.
         """
-        BATCH_SIZE = 10
+        BATCH_SIZE = 8
 
         # Wrap the single back-project function for gradient checkpointing
         back_project_single = jax.remat(XRayTransform3D._back_project_single)

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -388,6 +388,7 @@ class XRayTransform3D(LinearOperator):
         return XRayTransform3D._back_project(proj, self.matrices, self.input_shape)
 
     @staticmethod
+    @partial(jax.jit, static_argnames="det_shape")
     def _project(im: ArrayLike, matrices: ArrayLike, det_shape: Shape) -> snp.Array:
         r"""
         Args:
@@ -399,22 +400,25 @@ class XRayTransform3D(LinearOperator):
         MAX_SLICE_LEN = 10
         slice_offsets = list(range(0, im.shape[0], MAX_SLICE_LEN))
 
-        num_views = len(matrices)
-        proj = jnp.zeros((num_views,) + det_shape, dtype=im.dtype)
-        for view_ind, matrix in enumerate(matrices):
+        blank_view_plane = jnp.zeros(det_shape, dtype=im.dtype)
+
+        def project_single_matrix(matrix, init_plane):
+            proj_plane = init_plane
             for slice_offset in slice_offsets:
-                proj = proj.at[view_ind].set(
-                    XRayTransform3D._project_single(
-                        im[slice_offset : slice_offset + MAX_SLICE_LEN],
-                        matrix,
-                        proj[view_ind],
-                        slice_offset=slice_offset,
-                    )
+                proj_plane = XRayTransform3D._project_single(
+                    im[slice_offset : slice_offset + MAX_SLICE_LEN],
+                    matrix,
+                    proj_plane,
+                    slice_offset=slice_offset,
                 )
-        return proj
+            return proj_plane
+
+        mapped_project = jax.vmap(project_single_matrix, in_axes=(0, None))
+
+        return mapped_project(matrices, blank_view_plane)
 
     @staticmethod
-    @partial(jax.jit, donate_argnames="proj")
+    # @partial(jax.jit, donate_argnames="proj")
     def _project_single(
         im: ArrayLike, matrix: ArrayLike, proj: ArrayLike, slice_offset: int = 0
     ) -> snp.Array:
@@ -435,33 +439,49 @@ class XRayTransform3D(LinearOperator):
         return proj
 
     @staticmethod
+    @partial(jax.jit, static_argnames="input_shape")
     def _back_project(proj: ArrayLike, matrices: ArrayLike, input_shape: Shape) -> snp.Array:
         r"""
         Args:
-            proj: Input (set of) projection(s).
+            proj: Input projection data of shape (num_views, *det_shape).
             matrix: (num_views, 2, 4) array of homogeneous projection matrices.
-            input_shape: Shape of desired back projection.
+            input_shape: Shape of back projection.
         """
         MAX_SLICE_LEN = 10
         slice_offsets = list(range(0, input_shape[0], MAX_SLICE_LEN))
 
-        HTy = jnp.zeros(input_shape, dtype=proj.dtype)
-        for view_ind, matrix in enumerate(matrices):
-            for slice_offset in slice_offsets:
-                HTy = HTy.at[slice_offset : slice_offset + MAX_SLICE_LEN].set(
-                    XRayTransform3D._back_project_single(
-                        proj[view_ind],
-                        matrix,
-                        HTy[slice_offset : slice_offset + MAX_SLICE_LEN],
-                        slice_offset=slice_offset,
-                    )
-                )
-                HTy.block_until_ready()  # prevent OOM
+        # 1. Provide an accumulator buffer matching the inner target slice size
+        # This acts as the tracer buffer, preventing 'donated buffer' mismatches.
+        blank_im_slice_buffer = jnp.zeros((MAX_SLICE_LEN,) + input_shape[1:], dtype=proj.dtype)
 
-        return HTy
+        # 2. Extract specific image slices across ALL views simultaneously
+        def back_project_single_slice(slice_offset):
+            # We start with our empty, statically shaped sub-slice buffer
+            im_slice = blank_im_slice_buffer
+
+            # Sequentially accumulate contributions from all projection views into this slice
+            for view_ind, matrix in enumerate(matrices):
+                im_slice = XRayTransform3D._back_project_single(
+                    proj[view_ind],
+                    matrix,
+                    im_slice,
+                    slice_offset=slice_offset,
+                )
+            return im_slice
+
+        # 3. Use vmap to calculate all slice blocks in parallel
+        mapped_back_project = jax.vmap(back_project_single_slice)
+        all_slices = mapped_back_project(jnp.array(slice_offsets))
+
+        # 4. Reshape the stacked vmap output back into a continuous 3D image array
+        # vmap gives (num_slices, MAX_SLICE_LEN, Y, Z), we flatten the first two axes
+        im = all_slices.reshape((-1,) + input_shape[1:])
+
+        # Trim any padding if the image size isn't perfectly divisible by MAX_SLICE_LEN
+        return im[: input_shape[0]]
 
     @staticmethod
-    @partial(jax.jit, donate_argnames="HTy")
+    # @partial(jax.jit, donate_argnames="HTy")
     def _back_project_single(
         y: ArrayLike, matrix: ArrayLike, HTy: ArrayLike, slice_offset: int = 0
     ) -> snp.Array:

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -432,7 +432,6 @@ class XRayTransform3D(LinearOperator):
             proj,
             self.matrices,
             self.input_shape,
-            batch_size=self.batch_size,
             device=self.input_device,
         )
 
@@ -493,7 +492,6 @@ class XRayTransform3D(LinearOperator):
         proj: ArrayLike,
         matrices: ArrayLike,
         input_shape: Shape,
-        batch_size: int = 8,
         device: xc.Device | Sharding | None = None,
     ) -> snp.Array:
         r"""
@@ -501,8 +499,6 @@ class XRayTransform3D(LinearOperator):
             proj: Input projection data of shape (num_views, *det_shape).
             matrix: (num_views, 2, 4) array of homogeneous projection matrices.
             input_shape: Shape of back projection.
-            batch_size: Number of projections to compute in parallel.
-                Higher is faster but more memory intensive.
             device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
                 to which the output will be committed.
         """

--- a/scico/linop/xray/_xray.py
+++ b/scico/linop/xray/_xray.py
@@ -384,6 +384,7 @@ class XRayTransform3D(LinearOperator):
         input_shape: Shape,
         matrices: ArrayLike,
         det_shape: Shape,
+        batch_size: int = 8,
         input_dtype: DType = np.float32,
         input_device: xc.Device | Sharding | None = None,
         output_device: xc.Device | Sharding | None = None,
@@ -394,6 +395,8 @@ class XRayTransform3D(LinearOperator):
             matrices: (num_views, 2, 4) array of homogeneous projection
                matrices.
             det_shape: Shape of detector.
+            batch_size: Number of projections to compute in parallel.
+                Higher is faster but more memory intensive.
             input_dtype: Input array dtype.
             input_device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
                 for input arrays.
@@ -404,6 +407,7 @@ class XRayTransform3D(LinearOperator):
         self.input_shape: Shape = input_shape
         self.matrices = jnp.asarray(matrices, dtype=np.float32)
         self.det_shape = tuple(det_shape)  # in case det_shape is a list
+        self.batch_size = batch_size
         self.output_shape = (len(matrices), *det_shape)
         self.input_device = input_device
         self.output_device = output_device
@@ -419,21 +423,26 @@ class XRayTransform3D(LinearOperator):
     def project(self, im: ArrayLike) -> snp.Array:
         """Compute X-ray projection."""
         return XRayTransform3D._project(
-            im, self.matrices, self.det_shape, device=self.output_device
+            im, self.matrices, self.det_shape, batch_size=self.batch_size, device=self.output_device
         )
 
     def back_project(self, proj: ArrayLike) -> snp.Array:
         """Compute X-ray back projection"""
         return XRayTransform3D._back_project(
-            proj, self.matrices, self.input_shape, device=self.input_device
+            proj,
+            self.matrices,
+            self.input_shape,
+            batch_size=self.batch_size,
+            device=self.input_device,
         )
 
     @staticmethod
-    @partial(jax.jit, static_argnames="det_shape")
+    @partial(jax.jit, static_argnames=("det_shape", "batch_size"))
     def _project(
         im: ArrayLike,
         matrices: ArrayLike,
         det_shape: Shape,
+        batch_size: int = 8,
         device: xc.Device | Sharding | None = None,
     ) -> snp.Array:
         r"""
@@ -442,31 +451,21 @@ class XRayTransform3D(LinearOperator):
             matrix: (num_views, 2, 4) array of homogeneous projection
                 matrices.
             det_shape: Shape of detector.
+            batch_size: Number of projections to compute in parallel.
+                Higher is faster but more memory intensive.
             device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
                 to which the output will be committed.
         """
-        BATCH_SIZE = 8
 
-        # Apply gradient checkpointing to the underlying core operator
-        project_single = jax.remat(XRayTransform3D._project_single)
-
-        # Define projection behavior for a single matrix over the full image
         def project_single_matrix(matrix):
-            # Start with an empty detector plane baseline
-            init_plane = jnp.zeros(det_shape, dtype=im.dtype, device=device)
-
-            # Call the rematerialized operator on the full image
-            return project_single(
+            init_proj = jnp.zeros(det_shape, dtype=im.dtype, device=device)
+            return XRayTransform3D._project_single(
                 im,
                 matrix,
-                init_plane,
-                slice_offset=0,  # No manual loops: processed as a whole
+                init_proj,
             )
 
-        # Automatically chunk and execute views sequentially/parallelized via JAX.
-        # If len(matrices) is not divisible by BATCH_SIZE, JAX natively handles the
-        # remainder.
-        return jax.lax.map(project_single_matrix, matrices, batch_size=BATCH_SIZE)
+        return jax.lax.map(project_single_matrix, matrices, batch_size=batch_size)
 
     @staticmethod
     def _project_single(
@@ -494,6 +493,7 @@ class XRayTransform3D(LinearOperator):
         proj: ArrayLike,
         matrices: ArrayLike,
         input_shape: Shape,
+        batch_size: int = 8,
         device: xc.Device | Sharding | None = None,
     ) -> snp.Array:
         r"""
@@ -501,39 +501,26 @@ class XRayTransform3D(LinearOperator):
             proj: Input projection data of shape (num_views, *det_shape).
             matrix: (num_views, 2, 4) array of homogeneous projection matrices.
             input_shape: Shape of back projection.
+            batch_size: Number of projections to compute in parallel.
+                Higher is faster but more memory intensive.
             device: (optional) :class:`~jax.Device` or :class:`~jax.sharding.Sharding`
                 to which the output will be committed.
         """
-        BATCH_SIZE = 8
 
-        # Wrap the single back-project function for gradient checkpointing
-        back_project_single = jax.remat(XRayTransform3D._back_project_single)
+        init_volume = jnp.zeros(input_shape, dtype=proj.dtype, device=device)
 
-        # Process an individual view slice-by-slice natively via map mapping
-        def back_project_single_view(packed_inputs):
-            # Unpack the active iteration variables provided by lax.map
-            single_proj, single_matrix = packed_inputs
-
-            # Initialize a full-sized target volume structure for this single projection
-            # contribution
-            init_volume = jnp.zeros(input_shape, dtype=proj.dtype, device=device)
-
-            return back_project_single(
-                single_proj,
-                single_matrix,
-                init_volume,
-                slice_offset=0,  # Let JAX optimize the internal execution structure
+        def scan_func(volume, proj_matrix_tuple):
+            proj, matrix = proj_matrix_tuple
+            volume = XRayTransform3D._back_project_single(
+                proj,
+                matrix,
+                volume,
             )
+            return volume, None
 
-        # Map across the zip-like structure of projections and matrices.
-        # lax.map accumulates a stacked array of individual volume reconstructions.
-        individual_volumes = jax.lax.map(
-            back_project_single_view, (proj, matrices), batch_size=BATCH_SIZE
-        )
+        volume, _ = jax.lax.scan(scan_func, init_volume, (proj, matrices))
 
-        # Collapse the mapped axis by summing the independent view contributions
-        # to finalize the reconstructed 3D output image array.
-        return jnp.sum(individual_volumes, axis=0)
+        return volume
 
     @staticmethod
     def _back_project_single(


### PR DESCRIPTION
Improvements to `linop.xray.XRayTransform3D`, in particular:
- Forward and adjoint operations could previously not be jitted.
- Now ≈5x faster than astra rather than ≈10x slower. 

Notes:
- Improvements implemented with the assistance of Gemini
- This branch incorporates the fixes from #662.
- The approach in this branch includes removal of the manual batching (for memory use reduction) approach in the original implementation, relying instead on `jax` tools for this purpose, including using `batch_size` in `jax.lax.map`, and `jax.remat`.
- The original manual batching approach is retained in branch [brendt/xray-loops](/lanl/scico/tree/brendt/xray-loops). While the implementation in this branch is cleaner, that branch does seem to be ≈10% faster. Further tests (including quantification of both relative computation times and memory usage) and discussion would be appropriate before deciding which solution to adopt.