### PR TITLE
Add previously-overlooked change summary entry on `scico.plot` deprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.0.8   (unreleased)
 • Enable certain parameters of array creation functions to trigger
  ``BlockArray`` creation when they receive lists (currently ``device``).
 • New functional ``functional.BoxIndicator``.
+• Module ``scico.plot`` deprecated.
 • Support ``jaxlib`` and ``jax`` versions 0.5.0 to 0.10.2.
 • Support ``flax`` versions 0.8.0 to 0.12.7.
 • Various bug fixes and minor improvements.


### PR DESCRIPTION
Add previously-overlooked change summary entry on `scico.plot` deprecation.